### PR TITLE
Clarify tsa- + postposition

### DIFF
--- a/en/morphology.tex
+++ b/en/morphology.tex
@@ -172,7 +172,7 @@ in pronouns}\index{pronouns!short genitive}
 demonstrative pronoun ``that,'' and has the genitive in \N{tseyä}.
 In informal, rapid speech it may take the form \N{tsaw}, which
 may be used with postpositions (\N{tsawfa}), but may not take case
-marking (there is no \N{*tsawl}). However, the stem \N{tsa-} may be
+marking (there is no \N{*tsawl}).  However, the stem \N{tsa-} may be
 used with the case endings (\N{tsal, tsar}, etc.), or with a
 postposition (\N{tsafa}), again in rapid speech.
 \label{morph:pron:tsa}\index{tsaw@\textbf{tsaw}}\index{tsa'u@\textbf{tsa'u}}

--- a/en/morphology.tex
+++ b/en/morphology.tex
@@ -172,9 +172,9 @@ in pronouns}\index{pronouns!short genitive}
 demonstrative pronoun ``that,'' and has the genitive in \N{tseyä}.
 In informal, rapid speech it may take the form \N{tsaw}, which
 may be used with postpositions (\N{tsawfa}), but may not take case
-marking (there is no \N{*tsawl}).  However, the stem \N{tsa-} may be
-used with the case endings, \N{tsal, tsar}, etc., again in rapid
-speech.
+marking (there is no \N{*tsawl}). However, the stem \N{tsa-} may be
+used with the case endings (\N{tsal, tsar}, etc.), or with a
+postposition (\N{tsafa}), again in rapid speech.
 \label{morph:pron:tsa}\index{tsaw@\textbf{tsaw}}\index{tsa'u@\textbf{tsa'u}}
 \LNWiki{6/5/2010}{https://wiki.learnnavi.org/Canon/2010/March-June\%23History_of_Tsaw}
 \NTeri{3/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\#comment-917}


### PR DESCRIPTION
The text did mention that tsa- can be used with case endings, but not with postpositions. Such forms (like tsamì, tsafa, etc.) are allowed, as already mentioned by Pawl in the given source (http://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\#comment-917). So I think this was simply an oversight. This commit makes it clear that tsa- can be used with postpositions as well.