### PR TITLE
Fix some LaTeX compile errors in the slang section

### DIFF
--- a/en/pragma.tex
+++ b/en/pragma.tex
@@ -304,19 +304,19 @@ any conjunction.
 \NTeri{3/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/}
 
 
-\subsubsection{Slang} At the request of the community, Paul Frommer approved 
+\subsection{Slang} At the request of the community, Paul Frommer approved
 some constructions deviating from standard grammar that could be used as `slang'
 among the Na'vi in informal contexts, or as a way to have fun with the language.
 \index{register!slang}\
 
-\subsubsubsection{}The mood infixes \N{<ei>} and \N{<äng>}, normally used in verbs,
-may be inserted into \N{<srane>} \E{<yes>} and \N{<kehe>} \E{<no>} instead of using
+\subsubsection{}The mood infixes \N{\INF{ei}} and \N{\INF{äng}}, normally used in verbs,
+may be inserted into \N{srane} \E{yes} and \N{kehe} \E{no} instead of using
 adverbs to express a mood.
-\LNforum{19/04/2020}{https://forum.learnnavi.org/language-updates/regarding-some-memetic-uses-of-na'vi/}
+\LNForum{19/04/2020}{https://forum.learnnavi.org/language-updates/regarding-some-memetic-uses-of-na'vi/}
 
-\subsubsubsection{}Proper names may form a compound verb with \N{<si>} to express \E{<do as X>}
+\subsubsection{}Proper names may form a compound verb with \N{si} to express \E{do as X}
 as an extension to the current formation method of these verbs.
-\LNforum{19/04/2020}{https://forum.learnnavi.org/language-updates/regarding-some-memetic-uses-of-na'vi/}
+\LNForum{19/04/2020}{https://forum.learnnavi.org/language-updates/regarding-some-memetic-uses-of-na'vi/}
 
 
 \subsection{Clipped Register} In military settings certain features of


### PR DESCRIPTION
This changes subsubsubsection into just subsubsection (subsubsubsection doesn't exist, and for good reason... you'd get numbers like 7.3.3.3.1 which is getting a bit insane hrh). Also fixed `\LNForum` and uses `\INF{...}` instead of hardcoding angle brackets.