### PR TITLE
Simplify and fix Makefile, add clean target

### DIFF
--- a/en/Makefile
+++ b/en/Makefile
@@ -2,13 +2,19 @@
 #
 # This requires GNU make.
 
-# Run twice for cross references.
-%.pdf: %.tex
-	xelatex $< $@
-	makeindex $< $@
-	xelatex $< $@
+all: horen-lenavi
 
+horen-lenavi:
+	xelatex horen-lenavi
+	makeindex horen-lenavi
+	xelatex horen-lenavi
 
-all: horen-lenavi.pdf
-
-horen-lenavi.pdf: $(wildcard *.tex)
+clean:
+	rm *.ind
+	rm *.ilg
+	rm *.aux
+	rm *.out
+	rm *.idx
+	rm *.toc
+	rm *.log
+	rm *.pdf


### PR DESCRIPTION
This commit simplifies the build targets, and ensures that the index is compiled and included in the final PDF.

Running any of the following  will build the complete PDF:
- `make all`
- `make horen-lenavi`
- `make`

This commit also adds a `clean` target, for removing all files generated by compilers.