### PR TITLE
Update about new used with subclauses

### DIFF
--- a/en/syntax.tex
+++ b/en/syntax.tex
@@ -1194,7 +1194,7 @@ exceptional patterns.
 subclause with a different subject than that of the \N{new} clause.
 The verb is transitive in this construction, and the subclause is
 attached to \N{a fì'ut} or \N{futa} (\horenref{syn:clause-nom}) and
-takes the subjunctive. \label{syn:modal:new}\index{new@\textbf{new}}
+often but not always takes the subjunctive. \label{syn:modal:new}\index{new@\textbf{new}}
 \LNWiki{20/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
 
 \begin{quotation}


### PR DESCRIPTION
According to an example provided by KP and posted on the Kelutral server on September 15th, `<iv>` is not obligatory. Maybe it allows the distinction between an uncertain/wished action and an action that is actually done after the subject expresses a desire to do that. I prefer to word it like this since we don't have more information about it.