### PR TITLE
Some Updates and Fixes

### DIFF
--- a/en/horen-lenavi.tex
+++ b/en/horen-lenavi.tex
@@ -121,7 +121,7 @@
 \newcommand{\LNWiki}[2]{\nhorcitation{Wiki}{#1}{#2}}
 \newcommand{\LNForum}[2]{\nhorcitation{Forum}{#1}{#2}}
 \newcommand{\Ultxa}[2]{\nhorcitation{Ultxa}{#1}{#2}}
-\newcommand{\LanguageLog}{\nhorcitation{LangLog}{9/12/2009}{http://languagelog.ldc.upenn.edu/nll/?p=1977}}
+\newcommand{\LanguageLog}{\nhorcitation{LangLog}{9/12/2009}{https://languagelog.ldc.upenn.edu/nll/?p=1977}}
 
 
 \begin{document}
@@ -133,7 +133,7 @@
 \date{Version 1.30, \today\footnote{This work is licensed
     under the Creative Commons Attribution-ShareAlike License, version
     4.0.  To view a copy of this license, visit 
-    \texttt{http://creativecommons.org/licenses/by-sa/4.0/}.}}
+    \texttt{https://creativecommons.org/licenses/by-sa/4.0/}.}}
 \maketitle
 
 \setcounter{tocdepth}{2}

--- a/en/intro.tex
+++ b/en/intro.tex
@@ -17,7 +17,7 @@ which clarify language points.
 I rely heavily on the Corpus and Canon wiki pages at LearnNavi.org,
 without which resources this document would not be possible.  The
 recent appearance of Frommer's own blog has also provided
-material.\footnote{In late June 2010, \url{http://naviteri.org}}
+material.\footnote{In late June 2010, \url{https://naviteri.org}}
 
 
 \section{History of Decipherment}
@@ -31,7 +31,7 @@ had a few phrases.
 
 The big break came when someone among the IMDB refugees on their own
 forum posted the Na'vi word
-list.\footnote{\url{http://kcbluesman.websitetoolbox.com/post?id=4013403}
+list.\footnote{\url{https://kcbluesman.websitetoolbox.com/post?id=4013403}
 requires login}  It was transcribed from the \textit{Activist
 Survival Guide}.\footnote{Wilhelm, Maria; Mathison, Dirk (2009). \textit{James
 Cameron's Avatar: A Confidential Report on the Biological and Social
@@ -52,7 +52,7 @@ patientive.
 
 Our next big break came a few days later, with the Language Log guest
 blog post on December
-19th.\footnote{\url{http://languagelog.ldc.upenn.edu/nll/?p=1977}}
+19th.\footnote{\url{https://languagelog.ldc.upenn.edu/nll/?p=1977}}
 This is still fundamental reading for every student of Na'vi.  In it
 we learn a good deal about the Na'vi sound system.  It also told us
 enough about Na'vi grammar to guide all our future analysis of
@@ -128,7 +128,7 @@ use a single slash to separate lines, \N{Rerol tengkrr kerä
 Starting in September of 2011, links to citations for grammatical
 points are included for new material.  They occur at the end of a
 section, and look like this:
-\NTeri{11/7/2010}{http://naviteri.org/2010/07/diminutives-conversational-expressions/}.
+\NTeri{11/7/2010}{https://naviteri.org/2010/07/diminutives-conversational-expressions/}.
 Note that the dates follow European convention, Day/Month/Year.
 ``NT'' is for Frommer's blog, including his replies in comments,
 ``Wiki'' is for the LN.org Wiki, ``Forum'' is the LN.org forum, and

--- a/en/l-and-s.tex
+++ b/en/l-and-s.tex
@@ -43,7 +43,7 @@ emails to and from Frommer.  \label{l-and-s:cg}
 \subsubsection{} Because plain stops can be used as syllable codas,
 the more common ejective notation, \N{p'}, is too ambiguous:
 \N{tsap'alute} is not *\N{tsapxalute}.
-\LNWiki{21/12/2009}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+\LNWiki{21/12/2009}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
 
 \newpage
 \subsection{Vowels}
@@ -59,7 +59,7 @@ the more common ejective notation, \N{p'}, is too ambiguous:
 \subsubsection{} The phoneme \N{u} is always [u] in open syllables,
 and may be either [u] or [ʊ] in closed syllables.  \N{Lu} is always
 pronounced [lu], while \N{tsun} may be either [tsun] or [tsʊn].
-\LNWiki{20/5/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23The_Dual_sounds_of_.22u.22}
+\LNWiki{20/5/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23The_Dual_sounds_of_.22u.22}
 
 \subsubsection{} The diphthongs are \N{aw}, \N{ay}, \N{ew} and \N{ey}.
 Only in diphthongs will \N{w} or \N{y} be seen at the end of a
@@ -140,7 +140,7 @@ vowels will not occur next to each other (but see
 may occur at morpheme boundaries, for example in derivations,
 \N{tsukkäteng} $<$ \N{tsuk-} $+$ \N{käteng}, or with enclitics
 \N{Mo'atta} $<$ \N{Mo'at} $+$ \N{ta} (\horenref{l-and-s:stress:enclisis}).
-% http://naviteri.org/2011/03/“receptive-ability”-and-hesitation/comment-page-1/#comment-604
+% https://naviteri.org/2011/03/“receptive-ability”-and-hesitation/comment-page-1/#comment-604
 
 \subsubsection{} As is usual in most Human languages, some
 interjections break the rules, such as \N{oìsss}, a sound for anger, or
@@ -249,7 +249,7 @@ prenoun \N{pe+} causes lenition (\horenref{morph:pre:pe}).
 lenited (\horenref{numbers:dependent}). \index{lenition!numbers}
 
 \subsection{Proper Nouns} Proper nouns still undergo lenition. \N{oe kelku si mì Helutral} \E{I live in Hometree}
-\index{lenition!proper nouns}\NTeri{10/28/2010}{http://naviteri.org/2010/09/getting-to-know-you-part-2/}
+\index{lenition!proper nouns}\NTeri{10/28/2010}{https://naviteri.org/2010/09/getting-to-know-you-part-2/}
 
 \section{Morphophonology}
 
@@ -268,7 +268,7 @@ two \N{e}s, as in \N{me} $+$ \N{'eveng} $>$ *\N{meeveng} (note
 lenition), the two vowels contract to just one, \N{meveng}.
 \label{l-and-s:phonotactics:nsc} \index{dual!contraction}
 \index{trial!contraction}
-\LNWiki{20/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+\LNWiki{20/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
 
 \subsubsection{} When the prenoun prefixes end in the same vowel the
 following word starts with, they reduce to one, as in \N{tsatan} $<$
@@ -276,7 +276,7 @@ following word starts with, they reduce to one, as in \N{tsatan} $<$
 (\horenref{morph:prenoun:contraction}).\footnote{The glottal stop is a
 consonant, so \N{fì'ìheyu} from \N{fì-} $+$ \N{'ìheyu}.}
 \label{l-and-s:phonotactics:precontract}\index{prenoun!contraction}
-\LNWiki{18/5/2011}{http://wiki.learnnavi.org/index.php/Canon/2011/April-December\%23Kawtseng.2C_tsapo_and_prefixes}
+\LNWiki{18/5/2011}{https://wiki.learnnavi.org/index.php/Canon/2011/April-December\%23Kawtseng.2C_tsapo_and_prefixes}
 
 \subsubsection{} Contraction does not occur for indefinite \N{-o} or
 enclitic adpositions.  When two identical vowels occur next to each
@@ -285,7 +285,7 @@ other, they are written with a hyphen between them, \N{fya'o-o}
 does not technically have long vowels, the effect of long vowels
 occurs in this situation.  Take care to pronounce both \N{ä} in a word
 such as \N{zekwä-äo}.}\index{vowel!contraction!inhibited}
-% http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyuä#Phonological_Questions
+% https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyuä#Phonological_Questions
 
 \subsection{Pseudovowel Contraction} Due to the shape of the aspect
 infixes, \N{\INF{er}} and \N{\INF{ol}}, it is possible for the
@@ -295,15 +295,15 @@ syllable, the pseudovowel disappears, \N{pol\ACC{txe}}.  In a
 stressed syllable, the infix disappears, \N{*\ACC{f}\INF{er}\ACC{rr}fen} $>$
 \N{\ACC{frr}fen}.  Pseudovowels in monosyllables behave as though
 unaccented, \N{vol} from \N{*v\INF{ol}ll}. \index{pseudovowel!contraction}
-\LNWiki{23/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Misc_Answers}
-\NTeri{19/6/2012}{http://naviteri.org/2012/06/spring-vocabulary-part-3/}
+\LNWiki{23/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Misc_Answers}
+\NTeri{19/6/2012}{https://naviteri.org/2012/06/spring-vocabulary-part-3/}
 
 \subsection{Affect Infix Epenthesis} When the positive affect infix
 \N{\INF{ei}} is followed by the vowel \N{i}, \N{ì} or a pseudovowel, a
 \N{y} is inserted, \N{seiyi} $<$ \N{*s\INF{ei}i}, \N{veykrreiyìn} $<$
 \N{*veykrr\INF{ei}ìn}; \N{v\INF{ei}yll} $<$ \N{*veill}.
 \label{l-and-s:eiy-epenth}
-\NTeri{19/6/2012}{http://naviteri.org/2012/06/spring-vocabulary-part-3/}
+\NTeri{19/6/2012}{https://naviteri.org/2012/06/spring-vocabulary-part-3/}
 
 \subsection{Nasal Assimilation} In many compounds as well as in some
 idioms, final nasals assimilate to the position of the following
@@ -323,7 +323,7 @@ frequently appears as \N{\INF{ìyev}}, with backing of the first vowel.
 \N{\INF{äng}}, may be raised if it is immedately followed by the vowel
 \N{i}, becoming \N{\INF{eng}}, as in \N{tsap'alute \uwave{sengi}
 oe}.\label{l-and-s:eng}
-\Ultxa{2/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23.C3.A4ng.2Feng}
+\Ultxa{2/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23.C3.A4ng.2Feng}
 
 \subsection{Elision} In rapid speech final \N{-e} is frequently elided
 when the following word starts in a vowel.  \Npawl{Kìyevam$\not$e
@@ -337,7 +337,7 @@ no change in writing.  So, \N{nìayfo} \E{like them} is pronounced as
 \index{miì@\textbf{mì}!elision with plural}
 \index{siì@\textbf{sì}!elision with plural}
 \index{niì-@\textbf{nì-}!elision with plural}
-\NTeri{1/7/2010}{http://naviteri.org/2010/07/thoughts-on-ambiguity/}
+\NTeri{1/7/2010}{https://naviteri.org/2010/07/thoughts-on-ambiguity/}
 
 \subsubsection{} The vowel in \N{nì-} will usually elide before a
 stressed \N{e}, as in \N{nì-} + \N{etrìp} > \N{netrìp}. If the \N{e}
@@ -380,7 +380,7 @@ pronounced \N{we} when taking a suffix, retains the original spelling
 
 \subsubsection{} Before words starting with \N{y} the plural prefix
 \N{ay+} is unchanged, \N{ayyerik}.
-\LNWiki{18/4/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23ay.2Byerik}
+\LNWiki{18/4/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23ay.2Byerik}
 
 \subsection{Attributive Phrase Hyphenation} Certain short attributive
 phrases are written with hy\-phens joining the elements.

--- a/en/lingop.tex
+++ b/en/lingop.tex
@@ -42,7 +42,7 @@ have derivations in both \N{tì-} and \N{sä-}, as in \N{'ipu}
 \E{humorous}.  \N{Tì'ipu} is the abstract concept of being humorous,
 that is, humor in general.  \N{Sä'ipu} is a particular instance of being
 humorous --- for example, a joke.\\
-\NTeri{29/2/2012}{http://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/}
+\NTeri{29/2/2012}{https://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/}
 
 \subsubsection{} \N{Tì-} creates nouns from adjectives, verbs and
 occasionally other nouns, as in \N{tì\ACC{ngay}} \E{truth} from
@@ -87,7 +87,7 @@ thought of as fossilized abbreviations of forms like \N{nìfya'o a
 lìm} (\horenref{syn:nifyao}).  They are fixed lexical items, and do
 not have forms such as \N{*lìma} and \N{*sima}.
 \index{-a-@\textbf{-a-}!with adverbs}\index{aliìm@\textbf{alìm}}\index{asim@\textbf{asim}}
-\LNWiki{17/5/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Near.2C_Distant_and_Irregular_Adverbs}
+\LNWiki{17/5/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Near.2C_Distant_and_Irregular_Adverbs}
 
 
 \subsection{Prefix with Infix} There is a single derivation using the
@@ -120,7 +120,7 @@ patient of a verbal action, such as \N{\ACC{frr}tu} \E{guest}
 from \N{\ACC{frr}fen} \E{visit} (agent) \N{spe\ACC{'e}tu} \E{captive}
 from \N{spe\ACC{'e}} \E{capture} (patient).  This suffix is not
 productive.
-\NTeri{30/4/2021}{http://naviteri.org/2021/04/mipa-ayliu-mipa-sioeykting-new-words-new-explanations/}
+\NTeri{30/4/2021}{https://naviteri.org/2021/04/mipa-ayliu-mipa-sioeykting-new-words-new-explanations/}
 
 \subsubsection{} \N{-yu} creates agent nouns from verbs, to indicate a
 person who regularly performs some activity or role, as in
@@ -128,7 +128,7 @@ person who regularly performs some activity or role, as in
 productive, with regular verbs as well as \N{si}-verbs, such
 as \N{stiwisiyu} \E{mischief-maker,} from \N{stiwi si} \E{do mischief}.
 \index{-yu@\textbf{-yu}}
-\NTeri{11/7/2010}{http://naviteri.org/2010/07/diminutives-conversational-expressions/}
+\NTeri{11/7/2010}{https://naviteri.org/2010/07/diminutives-conversational-expressions/}
 \LNForum{30/10/2020}{https://forum.learnnavi.org/language-updates/yu-is-officially-productive-on-si-verbs/}
 
 
@@ -137,7 +137,7 @@ used freely to form diminutives, on both nouns and pronouns.  Personal
 names may lose syllables when taking this suffix, such as \N{Kamtsyìp} or
 \N{Kamuntsyìp} for \E{little Kamun}.  The diminutive has three uses.
 \label{lingop:dimin}\index{diminutive}\index{tsyiìp@\textbf{-tsyìp}}
-\NTeri{11/7/2010}{http://naviteri.org/2010/07/diminutives-conversational-expressions/}
+\NTeri{11/7/2010}{https://naviteri.org/2010/07/diminutives-conversational-expressions/}
 
 \subsubsection{} First, the diminutive form may be a primary lexical
 derivation.  Such words will end up in the dictionary, such as
@@ -168,7 +168,7 @@ teacher} from \N{karyu} \E{teacher}.  If the noun already ends in
 \E{acquaintance} from \N{'eylan} \E{friend}, \N{ikra\ACC{nay}}
 \E{forest banshee} from \N{ikran} \E{banshee}.  It isn't productive.
 \index{-nay@\textbf{-nay}}
-\NTeri{2/28/2013}{http://naviteri.org/2013/02/vospxi-ayol-posti-apup-short-post-for-a-short-month/}
+\NTeri{2/28/2013}{https://naviteri.org/2013/02/vospxi-ayol-posti-apup-short-post-for-a-short-month/}
 
 
 \subsection{Gender Suffixes} The gender suffixes are unusual in that
@@ -200,7 +200,7 @@ occurring daily; and \N{krro krro} \E{sometimes}.
 degree, \N{nì'ul'ul} \E{increasingly, more and more,}
 \N{nìnänän}\footnote{The reduplication is partial, since consonants
 cannot be doubled.} \E{less and less}.\\
-\NTeri{29/2/2012}{http://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/}
+\NTeri{29/2/2012}{https://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/}
 
 \section{Compounds}
 
@@ -238,7 +238,7 @@ fixed \N{N si}, with \N{si} getting all verb affixes.\label{lingop:si-const}
 
 \subsubsection{} In the verb \N{irayo si} \E{to thank} the order is
 less fixed.
-\LNWiki{12/5/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Word_Order_Issues}
+\LNWiki{12/5/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Word_Order_Issues}
 
 \subsubsection{} The normal \N{N si} word order is also broken for
 negation, \N{oe pamrel ke si} \E{I don't write} (\horenref{syn:neg:si-const}),
@@ -253,7 +253,7 @@ specialized, idiomatic meanings, such as \N{\ACC{ya}fkeyk}
 \E{weather}.  It is none\-the\-less widely productive, \Npawl{kilvanfkeyk
 lu fyape fìtrr?} \E{how's the condition of the river today?}
 \index{-fkeyk@\textbf{-fkeyk}}
-\NTeri{1/4/2011}{http://naviteri.org/2011/04/yafkeykiri-plltxe-frapo-everyone-talks-about-the-weather/}
+\NTeri{1/4/2011}{https://naviteri.org/2011/04/yafkeykiri-plltxe-frapo-everyone-talks-about-the-weather/}
 
 \subsection{Hì(')-} From the adjective \N{hì'i} \E{small}, the accented
 prefix \N{hì-} or \N{hì'-} is used in a few words to form diminutives,
@@ -265,7 +265,7 @@ as in \N{\ACC{hì}'ang} \E{insect} ($<$ \N{hì'} + \N{ioang}
 \subsection{-ìva} When the noun \N{ìlva} \E{flake, drop, chip} is used
 in compounds, the \N{l} drops, \N{\ACC{txe}pìva} \E{ash, cinder,}
 \N{\ACC{her}wìva} \E{snowflake}.
-\NTeri{1/4/2011}{http://naviteri.org/2011/04/yafkeykiri-plltxe-frapo-everyone-talks-about-the-weather/}
+\NTeri{1/4/2011}{https://naviteri.org/2011/04/yafkeykiri-plltxe-frapo-everyone-talks-about-the-weather/}
 \index{-iva@\textbf{-ìva}}\index{ilva@\textbf{ìlva}}
 
 \subsection{-nga'} This suffix, derived from the verb \N{nga'}
@@ -275,7 +275,7 @@ is much less common than \N{le-}.  It is possible for a noun to have
 both \N{le-} and \N{-nga'} derivations, \N{lepay} \E{watery} vs.\
 \N{\ACC{pay}nga'} \E{damp, humid}.
 \index{-nga'@\textbf{-nga'}}
-\NTeri{5/5/2011}{http://naviteri.org/2011/05/weather-part-2-and-a-bit-more-2/}
+\NTeri{5/5/2011}{https://naviteri.org/2011/05/weather-part-2-and-a-bit-more-2/}
 
 \subsection{-pin} Derived from the noun \N{'opin} \E{color}, this
 unaccented suffix is attached to color ad\-jec\-tives to form color nouns,
@@ -296,7 +296,7 @@ things other than people to indicate a natural grouping, such as
 \N{snatalioang} \E{a herd of sturmbeest}, \N{snautral} \E{a stand of
 trees}.  The prefix is used with non-living things to produce words,
 but this is not productive, \N{snatxärem} \E{skeleton}.
-\NTeri{31/3/2012}{http://naviteri.org/2012/03/spring-vocabulary-part-2/}
+\NTeri{31/3/2012}{https://naviteri.org/2012/03/spring-vocabulary-part-2/}
 \index{sna-@\textbf{sna-}}
 
 \subsection{-tsim} The noun \N{tsim} \E{source} can be suffixed to
@@ -307,7 +307,7 @@ source of confusion} from \N{yayayr} \E{confusion,}
 \N{\ACC{ing}yentsim} \E{mystery, riddle, enigma, conundrum}
 from \N{ingyen} \E{feeling of mystery or noncomprehension}.  Note that
 it doesn't change the accent.  This form is not productive.
-\NTeri{25/1/2013}{http://naviteri.org/2013/01/awvea-posti-zisita-amip-first-post-of-the-new-year/}
+\NTeri{25/1/2013}{https://naviteri.org/2013/01/awvea-posti-zisita-amip-first-post-of-the-new-year/}
 \index{-tsim@\textbf{-tsim}}
 
 \subsection{Tsuk-} Derived from \N{tsun fko}, this unaccented prefix
@@ -316,7 +316,7 @@ creates ability adjectives from transitive verbs, \N{tsuk\ACC{yom}}
 prefix \N{ke-}, which also causes no accent change here,
 \N{ketsuk\ACC{tswa'}} \E{unforgettable} (from \N{tswa'} \E{forget}).
 \index{tsuk-@\textbf{tsuk-}}\index{ketsuk-@\textbf{ketsuk-}}
-\NTeri{22/3/2011}{http://naviteri.org/2011/03/\%E2\%80\%9Creceptive-ability\%E2\%80\%9D-and-hesitation/}
+\NTeri{22/3/2011}{https://naviteri.org/2011/03/\%E2\%80\%9Creceptive-ability\%E2\%80\%9D-and-hesitation/}
 
 \subsubsection{} In addition, intransitive verbs may
 be combined with \N{tsuk-}, with a looser relationship between the
@@ -328,7 +328,7 @@ tsukhahaw} \E{one can sleep in the forest}.
 creates a noun meaning the ability to perform the action of the verb,
 \N{wemtswo} \E{ability to fight,} \N{roltswo} \E{ability to sing}.
 This suffix is related to the word \N{tsu'o} \E{ability}.
-\NTeri{31/3/2012}{http://naviteri.org/2012/03/spring-vocabulary-part-2/}
+\NTeri{31/3/2012}{https://naviteri.org/2012/03/spring-vocabulary-part-2/}
 \index{-tswo@\textbf{-tswo}}
 
 \subsubsection{} The suffix \N{-tswo} is attached to the noun or
@@ -343,7 +343,7 @@ loosely for the spawn of something bigger or a part of a larger whole,
 cause minor changes to the word it is attached to, \N{sä\ACC{num}vi}
 \E{lesson} from \N{sä\ACC{nu}me} \E{instruction, teaching}.
 \index{-vi@\textbf{-vi}}
-\LNWiki{14/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
+\LNWiki{14/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
 
 \subsection{``Kä-'' and ``Za-''} The two verbs of motion \N{kä} \E{go}
 and \N{za'u} \E{come} (reduced to just \N{za-}) are used in some

--- a/en/morphology.tex
+++ b/en/morphology.tex
@@ -236,12 +236,18 @@ number. \index{sno@\textbf{sno}!not marked for number}
 \hline
 1st exclusive   & \N{\ACC{o}he}  & \N{\ACC{mo}he}  & \N{\ACC{pxo}he}   & \N{ay\ACC{o}he} \\
 2nd       & \N{nge\ACC{nga}} & \N{menge\ACC{nga}} & \N{pxenge\ACC{nga}} & \N{aynge\ACC{nga}} \\
+3rd animate     & \N{\ACC{po}ho} & \QUAESTIO{\N{me\ACC{fo}ho}} & \QUAESTIO{\N{pxe\ACC{fo}ho}} & \QUAESTIO{\N{ay\ACC{fo}ho}} \\
 \end{tabular}
 \end{center}\index{pronouns!honorific}\label{morph:hon-pron}
 
 \subsubsection{} For the inclusive first person forms, use separate
 pronouns, \N{ohe ngengasì} (with enclitic \N{sì} \E{and}).
 \QUAESTIO{In the film we apparently get \N{ohengeyä}.}
+
+\subsubsection{} The 3rd person singular gender-neutral honorific pronoun 
+\N{poho} also has feminine and masculine forms \N{po\ACC{he}} \E{she} and 
+\N{po\ACC{han}} \E{he} respectively. Note that the stress shifts off of the o in these forms.
+\NTeri{28/2/2022}{https://naviteri.org/2022/02/lifyengteri-concerning-honorific-language/}
 
 %\QUAESTIO{\subsection{-po} We have \N{'awpo} and \N{fìpo}.  What about \N{tsapo}?}
 

--- a/en/morphology.tex
+++ b/en/morphology.tex
@@ -50,7 +50,7 @@ marked in the dictionary.
 \subsubsection{} Due to the similarity in sound between \N{y} and
 \N{i}, the patientive ending \N{-it} is simplified when suffixed to a
 diphthong ending in \N{y}, as in \N{keyeyt} \E{errors} instead of
-*\N{keyeyit}.  And due to similarity in sound between \N{w} and and
+*\N{keyeyit}.  And due to similarity in sound between \N{w} and
 \N{u}, the same simplification happens to the dative \N{-ur}, as in
 \N{'etnawr} \E{to/for a shoulder} instead of *\N{'etnawur}.
 \NTeri{1/25/2013}{http://naviteri.org/2013/01/awvea-posti-zisita-amip-first-post-of-the-new-year/}

--- a/en/morphology.tex
+++ b/en/morphology.tex
@@ -22,9 +22,9 @@ Genitive & \N{-yä}, \N{-o-ä}, \N{-u-ä} & \N{-ä} & \N{-ä} \\
 Topical  & \N{-ri} & \N{-ìri} & \N{-ri}  \\
 \end{tabular}\end{center}
 
-\noindent\LNWiki{24/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Declension_with_Diphthongs_and_Deixis}
+\noindent\LNWiki{24/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Declension_with_Diphthongs_and_Deixis}
 
-% For gen. with i: http://forum.learnnavi.org/language-updates/genitive-case-refinement-declension-of-tsaw/msg150927/#msg150927
+% For gen. with i: https://forum.learnnavi.org/language-updates/genitive-case-refinement-declension-of-tsaw/msg150927/#msg150927
 
 \subsubsection{} Note that words ending in the pseudo-vowels \N{ll}
 and \N{rr} take the consonant endings: \N{trr-ä}, \N{'ewll-it}.
@@ -37,7 +37,7 @@ from \N{lì'fya}.
 
 \subsubsection{} Nouns in \N{-ia} have the genitive in \N{-iä}, as in
 \N{soaiä} from \N{soaia}.
-\NTeri{25/5/2011}{http://naviteri.org/2011/05/some-miscellaneous-vocabulary/}
+\NTeri{25/5/2011}{https://naviteri.org/2011/05/some-miscellaneous-vocabulary/}
 % This used to be covered by a single example in following "case
 % refinement" section link; later generalized.
 
@@ -53,7 +53,7 @@ diphthong ending in \N{y}, as in \N{keyeyt} \E{errors} instead of
 *\N{keyeyit}.  And due to similarity in sound between \N{w} and
 \N{u}, the same simplification happens to the dative \N{-ur}, as in
 \N{'etnawr} \E{to/for a shoulder} instead of *\N{'etnawur}.
-\NTeri{1/25/2013}{http://naviteri.org/2013/01/awvea-posti-zisita-amip-first-post-of-the-new-year/}
+\NTeri{1/25/2013}{https://naviteri.org/2013/01/awvea-posti-zisita-amip-first-post-of-the-new-year/}
 
 \subsubsection{} A noun ending in the glottal stop may also take the
 dative in \N{-ru}, such as \Npawl{lì'fyaolo\uwave{'ru}}.  Otherwise
@@ -89,15 +89,15 @@ Topical    & \N{Kelnìri} & \N{Keln-ìri}, not \N{Kelnì-ri}
 \noindent Note that for the patientive and dative, only the forms that
 start with a vowel---\N{-it} and \N{-ur}---are permitted.  A form
 like \N{*Kelnti} is not a permitted Na'vi word shape.
-\NTeri{8/1/2022}{http://naviteri.org/2022/01/aawa-tipangkxotsyip-a-teri-horen-lifyaya-a-few-little-discussions-about-grammar/}
+\NTeri{8/1/2022}{https://naviteri.org/2022/01/aawa-tipangkxotsyip-a-teri-horen-lifyaya-a-few-little-discussions-about-grammar/}
 
 \subsection{Indefinite -o} A noun may take the indefinite suffix
 \N{-o}, ``one, some.''  Case endings follow the \N{-o}, such
 as \N{puk-o-t}.
 \index{-o@\textbf{-o}}\index{indefinite noun}
-\LNWiki{14/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23
+\LNWiki{14/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23
 A_Collection}
-\NTeri{5/9/2011}{http://naviteri.org/2011/09/\%E2\%80\%9Cby-the-way-what-are-you-reading\%E2\%80\%9D/comment-page-1/\%23comment-1093}
+\NTeri{5/9/2011}{https://naviteri.org/2011/09/\%E2\%80\%9Cby-the-way-what-are-you-reading\%E2\%80\%9D/comment-page-1/\%23comment-1093}
 
 \subsection{Number} Na'vi nouns and pronouns may be singular, dual,
 trial or plural (four or more).  Number is indicated by prefixes, all
@@ -156,7 +156,7 @@ pronunciation is indicated with the accenting underline on the
 If \N{oe} occurs after a word ending in \N{-u}, then \N{oe} is
 pronounced like \N{we}, with, for example, \N{'efu oe} pronounced
 like \N{'efu we}.
-\NTeri{30/4/2021}{http://naviteri.org/2021/04/mipa-ayliu-mipa-sioeykting-new-words-new-explanations/}
+\NTeri{30/4/2021}{https://naviteri.org/2021/04/mipa-ayliu-mipa-sioeykting-new-words-new-explanations/}
 
 \subsubsection{} The non-singular first person pronouns are either
 exclusive (excluding the person ad\-dres\-sed) or inclusive (including
@@ -219,7 +219,7 @@ used with the case endings (\N{tsal, tsar}, etc.), or with a
 postposition (\N{tsafa}), again in rapid speech.
 \label{morph:pron:tsa}\index{tsaw@\textbf{tsaw}}\index{tsa'u@\textbf{tsa'u}}
 \LNWiki{6/5/2010}{https://wiki.learnnavi.org/Canon/2010/March-June\%23History_of_Tsaw}
-\NTeri{3/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\#comment-917}
+\NTeri{3/8/2011}{https://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\#comment-917}
 
 \subsubsection{} The reflexive pronoun \N{sno} is not altered for
 number. \index{sno@\textbf{sno}!not marked for number}
@@ -354,8 +354,8 @@ system is not perfectly regular.
 \end{tabular}
 \end{center}\label{morph:correlatives}
 \footnotetext[\value{coraccent}]{May be accented on either syllable.}
-\LNWiki{18/5/2011}{http://wiki.learnnavi.org/index.php/Canon/2011/April-December\%23Kawtseng.2C_tsapo_and_prefixes}
-\NTeri{24/7/2011}{http://naviteri.org/2011/07/txantsana-ultxa-mi-siatll-great-meeting-in-seattle/comment-page-1/\%23comment-845} % kekem
+\LNWiki{18/5/2011}{https://wiki.learnnavi.org/index.php/Canon/2011/April-December\%23Kawtseng.2C_tsapo_and_prefixes}
+\NTeri{24/7/2011}{https://naviteri.org/2011/07/txantsana-ultxa-mi-siatll-great-meeting-in-seattle/comment-page-1/\%23comment-845} % kekem
 
 \subsubsection{} \QUAESTIO{Plurals for these are a bit funky.  Though
 \N{tsa'u} is from \N{tsa-} and \N{'u}, the plural is \N{(ay)sa'u}.
@@ -416,14 +416,14 @@ Plural & \N{pay\ACC{hem}}, \N{(ay)\ACC{hem}pe} \\
 \end{tabular}
 \end{center}
 
-\noindent\NTeri{30/7/2011}{http://naviteri.org/2011/07/number-in-na\%E2\%80\%99vi/}
+\noindent\NTeri{30/7/2011}{https://naviteri.org/2011/07/number-in-na\%E2\%80\%99vi/}
 
 \subsection{Fì'u and Tsaw in Clause Nominalization} \label{morph:fwa-tsawa}
 The demonstrative pronoun \N{fì'u} and the in\-an\-imate pronoun \N{tsaw}
 are used with the attributive particle \N{a} to nominalize clauses
 (\horenref{syn:clause-nom}).  When the attributive particle follows
 certain case forms of the pronoun, they contract:
-% http://forum.learnnavi.org/language-updates/txelanit-hivawl/
+% https://forum.learnnavi.org/language-updates/txelanit-hivawl/
 
 \begin{center}
 \begin{tabular}{rcc}
@@ -440,7 +440,7 @@ Topical & \N{\ACC{fu}ria} ($<$ \N{fì'uri a}) & \N{\ACC{tsa}ria} \\
 \index{fula@\textbf{fula}}
 \index{futa@\textbf{futa}}\index{tsata@\textbf{tsata}}
 \index{furia@\textbf{furia}}\index{tsaria@\textbf{tsaria}}
-\LNWiki{18/6/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23The_contrast_between_fwa.2Ftsawa.2C_furia.2Ftsaria}
+\LNWiki{18/6/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23The_contrast_between_fwa.2Ftsawa.2C_furia.2Ftsaria}
 \LNForum{21/4/2020}{https://forum.learnnavi.org/language-updates/tsa-words-the-complete-set/}
 
 \subsection{Fmawn and Tì'eyng in Clause Nominalization} While \N{fì'u}
@@ -467,7 +467,7 @@ Patientive & \N{teyngta} ($<$ \N{tì'eyngit a})
 and \N{faylì'u}, which are \N{fmawnta} ($<$ \N{fmawnit a}) and
 \N{fayluta} ($<$ \N{faylì'ut a}).  See \horenref{syn:quot:nominalized}
 for the syntax.
-\NTeri{31/8/2011}{http://naviteri.org/2011/08/reported-speech-reported-questions/}
+\NTeri{31/8/2011}{https://naviteri.org/2011/08/reported-speech-reported-questions/}
 
 
 \section{The Adjective}
@@ -527,7 +527,7 @@ be learned from the lexicon.  \index{verb!compound!infix location}
 \subsubsection{} A small number of verb+verb compounds take infixes in
 both elements of the compound, such as \N{kan'ìn} \E{specialize in},
 made up of \N{kan} \E{aim, intend} and \N{'ìn} \E{be busy}.
-\Ultxa{2/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Transitivity_and_Infix_Positions}
+\Ultxa{2/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Transitivity_and_Infix_Positions}
 
 \subsection{Pre-first Position} These infixes change transitivity.
 They are inserted before the vowel of the next-to-last syllable of a
@@ -542,13 +542,13 @@ Reflexive & \N{\INF{äp}} \\
 \end{tabular}
 \end{center}
 
-\noindent\LNWiki{1/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Reflexives_and_Naming} % reflexive
-\LNWiki{15/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Trials_.26_transitivity} % causative
+\noindent\LNWiki{1/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Reflexives_and_Naming} % reflexive
+\LNWiki{15/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Trials_.26_transitivity} % causative
 
 \subsubsection{} In casual conversation the reflexive perfective of
 \N{si}-construction verbs, \N{säpo\ACC{li}}, is often pronounced
 \N{spo\ACC{li}}.
-\NTeri{3/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/}
+\NTeri{3/8/2011}{https://naviteri.org/2011/08/new-vocabulary-clothing/}
 
 \subsubsection{} \index{reflexive!of a causative}
 The causative reflexive, ``cause oneself to,'' is formed
@@ -575,8 +575,8 @@ Past & \N{\INF{am}} & \N{\INF{alm}} & \N{\INF{arm}} \\
 \end{tabular}
 \end{center}
 \LanguageLog{}
-\LNWiki{27/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
-\LNWiki{19/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Evidential} %ìrm
+\LNWiki{27/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+\LNWiki{19/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Evidential} %ìrm
 
 \subsubsection{} The futures with \N{s} mark intention
 (\horenref{syn:verb:intenfut}).
@@ -595,9 +595,9 @@ Past & \N{\INF{imv}} & — & —
 \end{tabular}
 \end{center}
 
-\noindent\LNWiki{9/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
-\LNWiki{30/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Vocabulary_and_.3Ciyev.3E}
-\LNWiki{30/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Fused_-iv-_Infixes}
+\noindent\LNWiki{9/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+\LNWiki{30/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Vocabulary_and_.3Ciyev.3E}
+\LNWiki{30/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Fused_-iv-_Infixes}
 
 \subsubsection{} There are only two participle infixes.  They do not
 combine with tense, aspect or mood infixes. \index{participle!formation}
@@ -612,7 +612,7 @@ Passive & \N{\INF{awn}} \\
 \noindent Since the participles are adjectives that cannot be used as
 predicates, they will always occur with the attributive adjective
 affix \N{-a-} (\horenref{morph:adj-attr}, \horenref{syn:part:attr}).
-\LNWiki{13/3/2011}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Participial_Infixes}
+\LNWiki{13/3/2011}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Participial_Infixes}
 
 
 \subsection{Second Position} These infixes, which indicate speaker
@@ -629,7 +629,7 @@ Inferential, suppositional & \N{\INF{ats}} \\
 \end{tabular}
 \end{center}
 
-\noindent\LNWiki{19/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Evidential} % <ats>
+\noindent\LNWiki{19/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Evidential} % <ats>
 
 \subsection{Examples} The rules given above are a bit abstract, so I
 give here examples of some possible inflections for a few verb shapes.

--- a/en/morphology.tex
+++ b/en/morphology.tex
@@ -416,7 +416,7 @@ Plural & \N{pay\ACC{hem}}, \N{(ay)\ACC{hem}pe} \\
 \end{tabular}
 \end{center}
 
-\noindent\NTeri{30/7/2011}{http://naviteri.org/2011/07/number-in-na’vi/}
+\noindent\NTeri{30/7/2011}{http://naviteri.org/2011/07/number-in-na\%E2\%80\%99vi/}
 
 \subsection{Fì'u and Tsaw in Clause Nominalization} \label{morph:fwa-tsawa}
 The demonstrative pronoun \N{fì'u} and the in\-an\-imate pronoun \N{tsaw}

--- a/en/numbers.tex
+++ b/en/numbers.tex
@@ -1,5 +1,5 @@
 % Sun Dec  2 12:35:11 2012 - REORGANIZE the charts to look more like
-% http://forum.learnnavi.org/navi-lernen/das-navi-zahlensystem/
+% https://forum.learnnavi.org/navi-lernen/das-navi-zahlensystem/
 \nchapter{Numbers}
 \noindent The Na'vi language has an \textit{octal}, or base eight,
 number system, like a very small number of Human

--- a/en/pragma.tex
+++ b/en/pragma.tex
@@ -59,7 +59,7 @@ OVS & 0 & 1 & 1\\
 OSV & 0 & 2 & 2\\
 \end{tabular}
 \end{center}}
-\NTeri{19/3/2011}{http://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
+\NTeri{19/3/2011}{https://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
 
 \subsection{Word Order Effects} \index{word order!effects} Changes in
 word order can sometimes cause changes in grammar. \label{pragma:woe}
@@ -85,7 +85,7 @@ order of acceptability:
 \end{center}
 \footnotetext[\value{footnote}]{According to Frommer's blog, ``...in
 all but the most formal situations.''}
-\NTeri{19/3/2011}{http://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
+\NTeri{19/3/2011}{https://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
 
 \subsection{Focus} \index{focus}\index{word order!focus}\index{punch}
 Since free word order languages do not use word order for syntax, they
@@ -100,7 +100,7 @@ translated this sentence:
 \noindent\Npawl{Fkxilet a tsawfa poe ioi säpalmi ngolop \uwave{Va'rul}.}\\
 \indent\E{\uwave{Va'ru} is the one who created the necklace she was wearing.}
 \end{quotation}
-% http://naviteri.org/2011/08/new-vocabulary-clothing/
+% https://naviteri.org/2011/08/new-vocabulary-clothing/
 
 \noindent The focused, salient part of the answer to a question is
 similarly moved to the end of the clause:
@@ -115,10 +115,10 @@ similarly moved to the end of the clause:
 
 \noindent In English such focus can also be handled by emphasizing a
 particular word with stress, \E{\uline{Eytukan} saw Neytiri}.
-\NTeri{19/3/2011}{http://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
+\NTeri{19/3/2011}{https://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
 
 % Add a note about the keng example in:  ???   2018jan02
-% http://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/
+% https://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/
 
 \subsection{The English Passive} Although generations of English
 teachers have convinced many people that the passive voice is weak and
@@ -195,7 +195,7 @@ before even a leading conjunction,
 \noindent\Npawl{\uwave{Fori} mawkrra fa renten ioi säpoli holum.}\\
 \indent\E{After they put on their goggles, they left.}
 \end{quotation}
-% http://naviteri.org/2011/08/new-vocabulary-clothing/
+% https://naviteri.org/2011/08/new-vocabulary-clothing/
 
 \subsubsection{} Similarly, a topic may apply for multiple comments, 
 
@@ -230,7 +230,7 @@ I say, ``I wanted to see \E{Avatar,} but the line was too long,'' I
 can use the definite article with \E{line} not because we've been
 talking about lines, but because standing in line is something we're
 used to when seeing a popular film.  In comments on a recent blog
-post\footnote{\href{http://naviteri.org/2010/08/20/}{A
+post\footnote{\href{https://naviteri.org/2010/08/20/}{A
 Na'vi Alphabet}, August 20, 2010} Frommer says, \index{case!topical!as definite}
 
 \begin{quote}But if the message is indefinite, the topical case
@@ -281,12 +281,12 @@ noun or noun phrase, any genitive must also come after the adposition,
 as in \N{fa oeyä tsyokx} or \N{fa tsyokx oeyä} \E{with my hand}.  In
 poetry, the genitive may also come before the adposition, \N{oeyä fa
 tsyokx}. 
-\LNWiki{17/3/2012}{http://wiki.learnnavi.org/index.php/Canon/2012/January-June\%23A_poetic_license_and_a_note_on_adposition_position}
+\LNWiki{17/3/2012}{https://wiki.learnnavi.org/index.php/Canon/2012/January-June\%23A_poetic_license_and_a_note_on_adposition_position}
 
 \subsubsection{} In day-to-day speech a modal verb must come before
 its controlled verb (\horenref{syn:modal-syntax}).  In poetic or
 ceremonial language, the modal may follow.
-\NTeri{3/19/2011}{http://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
+\NTeri{3/19/2011}{https://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
 
 
 \subsection{Colloquial Register} The colloquial register presents
@@ -301,18 +301,18 @@ any conjunction.
 \noindent\Npawl{\uwave{Spängaw oel futa} fwa po kolä lu kxeyey.}\\
 \noindent Colloquial: \Npawl{\uwave{Spaw oe}, fwa po kolä längu kxeyey.}
 \end{quotation}
-\NTeri{5/4/2011}{http://naviteri.org/2011/04/\%E2\%80\%99a\%E2\%80\%99awa-li\%E2\%80\%99fyavi-amip\%E2\%80\%94a-few-new-expressions/}
+\NTeri{5/4/2011}{https://naviteri.org/2011/04/\%E2\%80\%99a\%E2\%80\%99awa-li\%E2\%80\%99fyavi-amip\%E2\%80\%94a-few-new-expressions/}
 
 \subsubsection{} In casual conversation the reflexive perfective of
 \N{si}-construction verbs, \N{säpo\ACC{li}}, is often pronounced
 \N{spo\ACC{li}}.
-\NTeri{3/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/}
+\NTeri{3/8/2011}{https://naviteri.org/2011/08/new-vocabulary-clothing/}
 
 \subsubsection{} The conjunction \N{tìk} (\horenref{syn:tìk}) can be
 used when a second event is an immediate con\-se\-quence of the first.  This
 can replace some uses of conditional \N{txo}, as in \Npawl{tsatxumit
 näk tìk terkup} \E{if you drink that poison, you'll immediately die}.
-\NTeri{31/12/2021}{http://naviteri.org/2021/12/zolau-niprrte-ma-3746-welcome-2022/}
+\NTeri{31/12/2021}{https://naviteri.org/2021/12/zolau-niprrte-ma-3746-welcome-2022/}
 
 \subsubsection{} \label{prag:colloq:omit}
 A few words can be omitted in colloquial speech, though there is no
@@ -334,7 +334,7 @@ requirement for them to be dropped: \N{lu}, \N{tok}, and \N{pum}.
 
 \noindent Note that because \N{tok} is transitive, the agentive and
 patientive endings are still required in \N{pol pesenget?}
-\NTeri{30/4/2021}{http://naviteri.org/2021/04/mipa-ayliu-mipa-sioeykting-new-words-new-explanations/}
+\NTeri{30/4/2021}{https://naviteri.org/2021/04/mipa-ayliu-mipa-sioeykting-new-words-new-explanations/}
 
 \subsection{Slang} At the request of the community, Paul Frommer approved
 some constructions deviating from standard grammar that could be used
@@ -364,10 +364,10 @@ grammar can be modified or omitted for brevity.
 their noun without using the attri\-bu\-tive affix \N{-a-}
 (\horenref{syn:part:attr}), \N{tìkan tawnatep} \E{target lost} (from
 the video game).
-\LNWiki{21/5/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Losing_and_registers}
+\LNWiki{21/5/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Losing_and_registers}
 
 \subsubsection{} Some pronoun genitives lose the final \N{-ä}, see
 \horenref{morph:pron:gen-clipped}.  This may be used casually, in
 non-military situations, among friends or close acquaintances.
-\LNWiki{21/5/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Losing_and_registers}
+\LNWiki{21/5/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Losing_and_registers}
 

--- a/en/semantics.tex
+++ b/en/semantics.tex
@@ -96,7 +96,7 @@ no overt direct object, \N{tìng nari!} \E{look at that!}  But they can
 be used with the dative for the thing perceived, \Npawl{poru tìng
 nari!} \E{look at him!} though \Npawl{poti nìn!} \E{look at him!} will
 be more common.
-\NTeri{27/11/2012}{http://naviteri.org/2012/11/renu-ayinanfyaya-the-senses-paradigm/}
+\NTeri{27/11/2012}{https://naviteri.org/2012/11/renu-ayinanfyaya-the-senses-paradigm/}
 
 \subsection{Phenomena} \index{perception!phenomena} \index{fkan@\textbf{fkan}} \index{perception!phenomena!fkan@\textbf{fkan}}
 To express the experience of phenomena the verb \N{fkan} is used with

--- a/en/syntax.tex
+++ b/en/syntax.tex
@@ -1327,7 +1327,7 @@ are: \N{fmi, kan, may', new, nulnew,} and \N{sto}.
 \N{futa} clause, \Npawl{pol oeru neykew futa oel yivom teyluti}
 \E{he made me want to eat teylu}, lit. \E{he made me want that I eat
 teylu}. \index{new@\textbf{new}!causative}
-\LNWiki{3/10/2010}{https://wiki.learnnavi.org/Canon/2010/UltxaAyharyuä\#He_made_me_want_to_make_you_eat_teylu}
+\LNWiki{3/10/2010}{https://wiki.learnnavi.org/Canon/2010/UltxaAyharyu\%C3\%A4\#He\_made\_me\_want\_to\_make\_you\_eat\_teylu}
 \LNForum{29/11/2020}{https://forum.learnnavi.org/language-updates/causative-with-new-and-other-modals/}
 
 

--- a/en/syntax.tex
+++ b/en/syntax.tex
@@ -2305,4 +2305,4 @@ or \N{tsawa} with a past or perfective indicative,
 \noindent Note that this refers to a past event that did happen and
 was the right thing to do, not an unfulfilled past action (which is
 another use of ``should'' in English).
-\NTeri{5/4/2011}{http://naviteri.org/2011/04/05/}
+\NTeri{5/4/2011}{https://naviteri.org/2011/04/\%e2\%80\%99a\%e2\%80\%99awa-li\%e2\%80\%99fyavi-amip\%e2\%80\%94a-few-new-expressions/}

--- a/en/syntax.tex
+++ b/en/syntax.tex
@@ -1241,6 +1241,7 @@ syntax:\footnote{\QUAESTIO{Other candidates: \N{flä} \E{succeed},
 \N{kom} & dare\\
 \N{may'} & try (experiential) \\
 \N{new} & want\footnotemark[\value{modalsnote}] \\
+\N{nulnew} & prefer \\
 \end{tabular}
 \hskip 3em
 \begin{tabular}{ll}
@@ -1266,6 +1267,7 @@ syntax:\footnote{\QUAESTIO{Other candidates: \N{flä} \E{succeed},
 \Ultxa{2/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23.C3.ACm.C3.ACy_and_modal_kan}
 \LNWiki{13/12/2012}{http://wiki.learnnavi.org/index.php/Canon/2012/July-December\%23.22sto.22_has_the_same_syntax_as_.22new.22}
 \NTeri{6/6/2019}{http://naviteri.org/2019/06/50a-liu-amip-40-new-words\%ef\%bb\%bf/}
+\NTeri{23/12/2020}{http://naviteri.org/2020/12/mrra-tipangkxotsyip-five-little-discussions/}
 
 \subsubsection{} Note that the modal verbs are considered intransitive
 with the subject of the modal phrase in the subjective case,

--- a/en/syntax.tex
+++ b/en/syntax.tex
@@ -88,7 +88,7 @@ vs. plural distributive?  Or always obligatory?}
 \subsubsection{} When used with an attributive numeral, nouns are not
 marked for number, \N{mrra zìsìt} \E{five years}.
 \index{plural!unmarked with numerals}
-\LNWiki{18/6/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Numbers_take_nouns_in_the_SINGULAR.}
+\LNWiki{18/6/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Numbers_take_nouns_in_the_SINGULAR.}
 
 \subsubsection{} The adjectives of quantity --- \N{'a'aw} \E{several},
 \N{hol} \E{few}, \N{pxay} \E{many}, \N{polpxay, holpxaype} \E{how
@@ -96,7 +96,7 @@ many?} --- also take singular nouns in attributive phrases, \Npawl{lu
 poru \uwave{'a'awa 'eylan}} \E{he has \uwave{several friends}}.
 \index{'a'aw@\textbf{'a'aw}}\index{hol@\textbf{hol}}\index{pxay@\textbf{pxay}}
 \index{polpxay@\textbf{polpxay}}\index{holpxaype@\textbf{holpxaype}}
-\NTeri{16/7/2010}{http://naviteri.org/2010/07/vocabulary-update/}
+\NTeri{16/7/2010}{https://naviteri.org/2010/07/vocabulary-update/}
 
 \subsubsection{} In colloquial speech, number may be marked with the
 adjective \N{pxay} \E{many}, \Npawl{lu awngar \uwave{aytele apxay} a
@@ -121,12 +121,12 @@ same entity, express number only once per clause.''\label{syn:noun:concord}
 number since the pronouns are already marked, and the same for
 \N{'eylan} in the third sentence.  But see \horenref{syn:pron:q-number}
 for the question pronoun \N{tupe}.
-\NTeri{30/7/2011}{http://naviteri.org/2011/07/number-in-na\%E2\%80\%99vi/}
+\NTeri{30/7/2011}{https://naviteri.org/2011/07/number-in-na\%E2\%80\%99vi/}
 
 \subsubsection{} General statements about a group or class use nouns
 in the singular, \Npawl{nantangìl yom yerikit}, \E{viperwolves eat
 hexapedes}.   \index{general statements} 
-\NTeri{30/7/2011}{http://naviteri.org/2011/07/number-in-na\%E2\%80\%99vi/}
+\NTeri{30/7/2011}{https://naviteri.org/2011/07/number-in-na\%E2\%80\%99vi/}
 
 \subsection{Indefinite} The adjective \N{lahe} \E{other} has the sense
 of \E{else} when used with indefinite nouns having the suffix \N{-o},
@@ -150,7 +150,7 @@ though not always, takes the subjunctive,
 \noindent\Npawl{Pukit aketsran ivinan.}\\
 \indent\E{Read any book at all.}
 \end{quotation}
-\noindent\NTeri{3/31/2013}{http://naviteri.org/2013/03/whoever-whatever-whenever/}
+\noindent\NTeri{3/31/2013}{https://naviteri.org/2013/03/whoever-whatever-whenever/}
 
 \subsection{Apposition} Nouns in apposition\footnote{Nouns are
 described as \textit{in apposition} when they occur immediately next
@@ -168,8 +168,8 @@ use.} \index{apposition}
 \subsubsection{Titles} Titles act as noun modifiers, and are thus not
 declined when used with proper names.  The dative of \N{Karyu Pawl}
 ``teacher Paul'' is \N{Karyu Pawlur}. \index{case!with titles}
-% http://forum.learnnavi.org/language-updates/definitive-answers-on-compound-nouns/
-% Followup and details: http://forum.learnnavi.org/language-updates/compound-nounsfinal-decision!/
+% https://forum.learnnavi.org/language-updates/definitive-answers-on-compound-nouns/
+% Followup and details: https://forum.learnnavi.org/language-updates/compound-nounsfinal-decision!/
 
 \subsection{Adjective Attribution} Attributive adjectives are joined
 to the noun they modify with the affix \N{-a-} (see
@@ -200,13 +200,13 @@ of the language community}.
 other than  Adj - N - Adj given above, the adjectives must be put
 into an attributive clause with \N{lu}, \Npawl{yayo a lu lor sì hì'i}
 \E{a small, pretty bird}.
-\Ultxa{2/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Multiple_Attributives}
+\Ultxa{2/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Multiple_Attributives}
 
 \subsubsection{} A single adjective may be repeated on both sides of
 the noun to mark intensity.  The second adjective receives the phrase
 stress, \Npawl{lu po lora tuté \uwave{alor}} \E{she's an extremely
 beautiful woman.}
-\NTeri{2/28/2013}{http://naviteri.org/2013/02/vospxi-ayol-posti-apup-short-post-for-a-short-month/}
+\NTeri{2/28/2013}{https://naviteri.org/2013/02/vospxi-ayol-posti-apup-short-post-for-a-short-month/}
 
 \subsubsection{} When repeating a noun with different adjectives
 (``the big dog, the little dog, the yappy dog,'' etc.) the prop
@@ -282,8 +282,8 @@ with adverbs.  \label{syntax:adj-eql-comp}
 \index{adjective!equal comparison}\index{nìftxan@\textbf{nìftxan}}
 \index{case!topical!point of comparison}
 \index{na@\textbf{na}!point of comparison}
-\LNWiki{1/12/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/October-December\#As_ADJ.2FADV_as_N.2FPRN}
-%% CITE: http://wiki.learnnavi.org/index.php/Canon/2010/October-December#As_ADJ.2FADV_as_N.2FPRN
+\LNWiki{1/12/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/October-December\#As_ADJ.2FADV_as_N.2FPRN}
+%% CITE: https://wiki.learnnavi.org/index.php/Canon/2010/October-December#As_ADJ.2FADV_as_N.2FPRN
 
 
 \subsection{Direct Address}
@@ -343,7 +343,7 @@ been, too.  Note the answers to these questions,
 
 \noindent The plural forms ask for the identity of individual members,
 while the singular asks about a group characteristic.
-% http://naviteri.org/2011/07/number-in-na’vi/
+% https://naviteri.org/2011/07/number-in-na’vi/
 
 \subsection{Similarity} Pronouns may take the adverbial prefix
 \N{nì-}, producing a form like \N{nìnga} \E{like you}. These forms
@@ -414,7 +414,7 @@ Note that the reflexive can anticipate the noun it refers to, as
 in \Npawl{sìpawmìri sneyä aynumeyuä karyu 'eyng} \E{the teacher
 responds to his students' questions}.  Here \N{sneyä} is coming
 before \N{karyu} \E{teacher}.
-% http://naviteri.org/2020/05/tipusawm-tiuseyng-si-okvur-a-eltur-titxen-si-asking-answering-and-an-interesting-story/
+% https://naviteri.org/2020/05/tipusawm-tiuseyng-si-okvur-a-eltur-titxen-si-asking-answering-and-an-interesting-story/
 
 \N{Sno} is for third person antecedents only.
 \LNWiki{23/1/2018}{https://wiki.learnnavi.org/Canon/2018}
@@ -460,7 +460,7 @@ To focus contrasting elements, forms of the prenouns \N{fì-} and
 
 \noindent There is also a vocal constrastive stress on the independent
 forms of \N{fì'u} and \N{tsa'u} in this con\-struc\-tion.
-\NTeri{31/12/2011}{http://naviteri.org/2011/12/one-more-for-2011/}
+\NTeri{31/12/2011}{https://naviteri.org/2011/12/one-more-for-2011/}
 
 
 \section{Use of the Cases}
@@ -487,7 +487,7 @@ subjective to indicate a duration of time, \Nfilm{\uwave{zìsìto amrr}
 ftolia ohe} \E{I studied \uwave{for five years}}, \Npawl{herwì zereiup
 \uwave{fìtrro nìwotx}!} \E{It's been snowing \uwave{all day}!}
 \index{-o@\textbf{-o}!in time expressions}
-\LNWiki{1/12/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/October-December\#Duration_and_Loan_Word.2C_.22Jesus.22}
+\LNWiki{1/12/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/October-December\#Duration_and_Loan_Word.2C_.22Jesus.22}
 
 \subsection{Agentive} The agentive case is used for the subject of
 transitive verbs, \N{\uwave{oel} ngati kameie} \E{I See you}.
@@ -515,7 +515,7 @@ possession, where English uses the verb ``have,'' \N{lu oeru ikran}
 \E{I have an ikran}.  In this construction the verb usually comes
 first in the clause.  \index{case!dative!with \textbf{lu}}
 \index{lu@\textbf{lu}!with dative}
-\LNWiki{28/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Dative_.2B_copula_possessive}
+\LNWiki{28/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Dative_.2B_copula_possessive}
 
 \subsubsection{} The dative of interest limits the scope of an
 adjective to the judgement \QUAESTIO{or benefit} of a particular
@@ -562,7 +562,7 @@ The topical has a few more fixed uses, as well.\index{case!topical}
 the clause as possible: first in a main clause, but after the
 conjunction if in a subordinate clause. \index{case!topical!word order}
 \label{syn!topical!word-order}
-\LNWiki{8/10/2011}{http://wiki.learnnavi.org/index.php/Canon/2011/April-December\%23Topical_Position}
+\LNWiki{8/10/2011}{https://wiki.learnnavi.org/index.php/Canon/2011/April-December\%23Topical_Position}
 
 \subsubsection{} The topical is often used with the \N{si}-verb
 \N{irayo si} \E{to thank} to indicate the thing for which you're
@@ -594,7 +594,7 @@ not fall immediately next to the topical.
 \index{possession!inalienable}\label{syn:topical:poss}
 \index{case!topical!inalienable possession}
 \index{topical!inalienable possession}
-\NTeri{11/7/2010}{http://naviteri.org/2010/07/diminutives-conversational-expressions/}
+\NTeri{11/7/2010}{https://naviteri.org/2010/07/diminutives-conversational-expressions/}
 % oeri ta peyä fahew akewong ontu teya längu.
 
 \subsubsection{} The topical can be used for the point of comparison
@@ -635,7 +635,7 @@ not \N{fo kilvanmì *hllkxem}.
 However, whatever word immediately follows a non-enclitic adposition
 will be lenited.  It doesn't have to be the noun, \N{mì hivea trr}
 \E{on the seventh day} (not \N{*mì kivea srr}).
-\LNWiki{24/8/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/July-September\%23Fmawno}
+\LNWiki{24/8/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/July-September\%23Fmawno}
 
 \subsubsection{} Since lenition alone is also used as the short plural
 (\horenref{morph:short-plural}), there is a chance for number
@@ -643,7 +643,7 @@ uncertainty depending on the conversational context.  To be clear
 about number, use the full plural prefix \N{ay+}; the lenited form
 without \N{ay+} should be interpreted as singular.
 \index{plural!short!with leniting adpositions}\label{syn:adp:short-plural}
-\NTeri{1/7/2010}{http://naviteri.org/2010/07/thoughts-on-ambiguity/}
+\NTeri{1/7/2010}{https://naviteri.org/2010/07/thoughts-on-ambiguity/}
 
 
 %\subsection{Äo} \E{Below}.  \N{Äo Utral Aymokriyä} \E{under the Tree
@@ -694,7 +694,7 @@ without \N{ay+} should be interpreted as singular.
 %skxirftumfa herum} \E{blood is coming out of (from inside of) the
 %wound}.
 %\index{ftumfa@\textbf{ftumfa}}\label{syn:adp:ftumfa}
-%\NTeri{25/4/2013}{http://naviteri.org/2013/04/wheres-the-bathroom-and-other-useful-things/}
+%\NTeri{25/4/2013}{https://naviteri.org/2013/04/wheres-the-bathroom-and-other-useful-things/}
 %
 %\subsection{Hu} \E{With}.  Of accompaniment only --- do not confuse
 %with \N{fa} (\horenref{syn:adp:fa}).  \N{Tsun oe ngahu pivängkxo a
@@ -715,7 +715,7 @@ without \N{ay+} should be interpreted as singular.
 %\subsubsection{} It also means \E{according to,} \Npawl{ìlä Feyral,
 %muntxa soli Ralu sì Newey nìwan mesrram} \E{according to Peyral,
 %Ralu and Newey were secretly married the day before yesterday.}
-%\NTeri{5/7/2012}{http://naviteri.org/2012/07/meetings-waterfalls-and-more/}
+%\NTeri{5/7/2012}{https://naviteri.org/2012/07/meetings-waterfalls-and-more/}
 %
 %\subsection{Ka} \E{Across, covering}.  Do not confuse with
 %\N{few} (\horenref{syn:adp:few}).
@@ -725,13 +725,13 @@ without \N{ay+} should be interpreted as singular.
 %trrkam} (or \N{kam trr a'a'aw}) \E{he started to use the bow several
 %days ago}.
 %\index{kam@\textbf{kam}}\label{syn:adp:kam}
-%\NTeri{24/9/2011}{http://naviteri.org/2011/09/miscellaneous-vocabulary/}
+%\NTeri{24/9/2011}{https://naviteri.org/2011/09/miscellaneous-vocabulary/}
 %
 %\subsection{Kay} \E{From now (in the future)}.  \Npawl{Zaya'u Sawtute
 %fte awngati skiva'a kay zìsìt apxey} (or \N{pxeya zìsìtkay}) \E{the
 %Sky People will come to destroy us three years from now!}
 %\index{kay@\textbf{kay}}\label{syn:adp:kay}
-%\NTeri{24/9/2011}{http://naviteri.org/2011/09/miscellaneous-vocabulary/}
+%\NTeri{24/9/2011}{https://naviteri.org/2011/09/miscellaneous-vocabulary/}
 %
 %\subsection{Kip} \E{Among}.  \Nfilm{Tivìran po ayoekip} \E{let her walk
 %among us}.
@@ -822,7 +822,7 @@ without \N{ay+} should be interpreted as singular.
 %\uwave{perish to} the enemy within or the enemy without;}
 %\Npawl{zola’u nìprrte’ ne pìlok Na’\-vi\-te\-ri} \E{welcome to the
 %Na'viteri blog}.
-%\NTeri{29/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Intentional_Future_Details}
+%\NTeri{29/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Intentional_Future_Details}
 %
 %\subsubsection{} \N{Ne} may be used to disambiguate the predicate of
 %the verb \N{slu} \E{become} (\horenref{syn:predicate:slu-ne}).
@@ -836,7 +836,7 @@ without \N{ay+} should be interpreted as singular.
 %lake} (on the other side) vs.\ \Npawl{fo kelku si nuä ora} \E{they
 %live beyond the lake} (at a great distance and out of sight).
 %\index{nuaä@\textbf{nuä}}\label{syn:adp:nuä}
-%\NTeri{15/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\%23comment-986}
+%\NTeri{15/8/2011}{https://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\%23comment-986}
 %
 %\subsection{Pxaw} \E{Around}.  \N{Po pxaw txep srew} \E{he danced
 %around the fire}.
@@ -867,7 +867,7 @@ without \N{ay+} should be interpreted as singular.
 %\Npawl{Sko Sahìk ke tsun oe mìftxele tsngivawvìk} \E{as Tsahik, I
 %cannot weep over this matter}.
 %\index{sko@\textbf{sko}}\label{syn:adp:sko}
-%\NTeri{31/3/2012}{http://naviteri.org/2012/03/spring-vocabulary-part-2/}
+%\NTeri{31/3/2012}{https://naviteri.org/2012/03/spring-vocabulary-part-2/}
 %
 %\subsection{Sre (+), Pxisre (+)}  \E{Before (time)}
 %\index{sre@\textbf{sre}}\label{syn:adp:sre}
@@ -891,7 +891,7 @@ without \N{ay+} should be interpreted as singular.
 %\subsubsection{} With transitive verbs \N{ta} is more likely to be
 %used to indication motion than \N{ftu}, as in \Npawl{pot 'aku
 %fìtsengta} \E{get him out of here!}
-%\NTeri{15/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\%23comment-994}
+%\NTeri{15/8/2011}{https://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\%23comment-994}
 %
 %
 %\subsection{Takip} \E{From among}
@@ -921,7 +921,7 @@ without \N{ay+} should be interpreted as singular.
 %\Npawl{Peyä tsatìpe'un a sweylu txo wivem ayoeng Omatikayawä lu fe'}
 %\E{his decision that we should fight against the Omaticaya was a bad one}.
 %\index{waä@\textbf{wä}}\label{syn:adp:wä}
-%%http://naviteri.org/2011/07/txantsana-ultxa-mi-siatll-great-meeting-in-seattle/
+%%https://naviteri.org/2011/07/txantsana-ultxa-mi-siatll-great-meeting-in-seattle/
 %
 %\subsection{Yoa} \E{In exchange for,} primarily used with verbs of
 %trade and exchange, \Npawl{oel tolìng ngaru tsnganit yoa fkxen} \E{I
@@ -930,7 +930,7 @@ without \N{ay+} should be interpreted as singular.
 %rol oer} \E{I loaned Peyral a hair ornament in exchange for her
 %singing to me}.
 %\index{yoa@\textbf{yoa}}\label{syn:adp:yoa}
-%\NTeri{28/2/2014}{http://naviteri.org/2014/02/barter-and-exchange/}
+%\NTeri{28/2/2014}{https://naviteri.org/2014/02/barter-and-exchange/}
 
 \section{Adverbs}
 \index{adverbs}
@@ -968,7 +968,7 @@ adverbs, \N{'ul... 'ul} \E{the more... the more} and \N{nän... nän}
 \noindent\Npawl{Nän yom kxamtrr, 'ul 'efu ohakx kaym.}\\
 \noindent\E{The less you eat at noon, the hungrier you’ll feel in the evening.}
 \end{quotation}
-\noindent\NTeri{29/2/2012}{http://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/}
+\noindent\NTeri{29/2/2012}{https://naviteri.org/2012/02/trr-asawnung-lefpom-happy-leap-day/}
 
 \subsection{Fìtxan and Nìftxan} Both adverbs \N{fìtxan} and
 \N{nìftxan} are used with the conjunction \N{kuma}
@@ -982,24 +982,24 @@ adverbs, \N{'ul... 'ul} \E{the more... the more} and \N{nän... nän}
 
 \noindent In these constructions the \N{akum/kuma} must be contiguous
 with the \N{fìtxan/nìftxan}.
-\NTeri{19/6/2012}{http://naviteri.org/2012/06/spring-vocabulary-part-3/}
+\NTeri{19/6/2012}{https://naviteri.org/2012/06/spring-vocabulary-part-3/}
 
 \subsection{Keng} The adverb \N{keng}, \E{even}, is used to prop up
 unexpected information, \N{yom teylut \uwave{keng oel}}
 \E{\uwave{even I} eat teylu.}
 \index{keng@\textbf{keng}}
-\LNWiki{31/12/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/October-December\%23Keng}
+\LNWiki{31/12/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/October-December\%23Keng}
 
 \subsection{Li}  The primary meaning of \N{li} is \E{already},
 \Npawl{tìkangkem li hasey lu} \E{the work is already finished.}
 \index{li@\textbf{li}} 
-\NTeri{20/2/2011}{http://naviteri.org/2011/02/new-vocabulary-part-2/}
+\NTeri{20/2/2011}{https://naviteri.org/2011/02/new-vocabulary-part-2/}
 
 \subsubsection{``Not Yet''} The negative, \N{ke li}, means ``not
 yet,'' and uses pleonastic negation (\horenref{syn:neg:pleon}),
 \N{fo ke li ke polähem} \E{they have not yet arrived}.
 \index{not yet}\index{ke@\textbf{ke}!\textbf{ke li}}
-\NTeri{4/9/2011}{http://naviteri.org/2011/09/\%E2\%80\%9Cby-the-way-what-are-you-reading\%E2\%80\%9D/comment-page-1/\%23comment-1092}
+\NTeri{4/9/2011}{https://naviteri.org/2011/09/\%E2\%80\%9Cby-the-way-what-are-you-reading\%E2\%80\%9D/comment-page-1/\%23comment-1092}
 
 
 
@@ -1040,7 +1040,7 @@ the Na'vi language}, \Npawl{tìfyawìntxuri oeyä perey aynga
 \subsubsection{``Both''} With dual number, the sense of \N{nìwotx} is
 \E{both,} \N{mefo nìwotx yolom} \E{they both ate}.
 \index{nìwotx@\textbf{nìwotx}!with dual}\index{both}
-\NTeri{15/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/}
+\NTeri{15/8/2011}{https://naviteri.org/2011/08/new-vocabulary-clothing/}
 
 \subsection{Nìfya'o} A noun phrase built on \N{fya'o} can be used
 freely to produce adverbs of manner.  In this construction the entire
@@ -1067,14 +1067,14 @@ told him that, too}.
 \subsubsection{} They can even be used together, \Npawl{furia nga lu
 nitram, lu oe kop nitram nìteng} \E{since you're happy, I, too, am
 also happy}.
-% http://naviteri.org/2011/05/weather-part-2-and-a-bit-more-2/comment-page-1/#comment-779
+% https://naviteri.org/2011/05/weather-part-2-and-a-bit-more-2/comment-page-1/#comment-779
 
 \subsection{Sunkesun} The adverb \N{\ACC{sun}kesun} \E{like it or not}
 is a shortened form of \N{sunu ke sunu} with the default addressee
 being \E{you}, \Npawl{sunkesun po slayu olo'eyktan} \E{whether you
 like it or not, he's going to become chief.}
 \index{sunkesun@\textbf{sunkesun}}
-\NTeri{6/6/2019}{http://naviteri.org/2019/06/50a-liu-amip-40-new-words/}
+\NTeri{6/6/2019}{https://naviteri.org/2019/06/50a-liu-amip-40-new-words/}
 
 \subsubsection{} Note that \N{sunkesun} can only be addressed to the
 listener, otherwise one must use a \N{ftxey... fuke}
@@ -1137,7 +1137,7 @@ presents a state of affairs as on\-going, it can be used in complex
 sentences to indicate simultaneous action, \Npawl{fìtxon yom tengkrr
 \uwave{teruvon}} \E{this night (we) eat while leaning}.
 \index{imperfective!simultaneous}
-\LNWiki{14/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
+\LNWiki{14/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
 
 \subsection{Anterior Perfective} In complex sentences, the perfective
 in a subordinate clause can indicate the completion of an action prior
@@ -1195,7 +1195,7 @@ phrases like, ``if only'' or ``I wish,'' \N{nìrangal lirvu oeyä
 frrnenur lora sanhì} \E{I wish my children had pretty stars},
 \N{nìrangal oel tslilvam nì'ul} \E{if only I had understood more}.
 \index{nìrangal@\textbf{nìrangal}}
-\LNWiki{14/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
+\LNWiki{14/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
 
 \subsection{Modal Complement} \index{modal verb}
 The verbal complement to a modal verb, such as \N{zene} \E{must},
@@ -1224,7 +1224,7 @@ never \N{*oe new tsimve'a}.
 
 Except in poetry or ceremonial language, the modal verb will always
 come before the control\-led verb.
-\NTeri{3/19/2011}{http://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
+\NTeri{3/19/2011}{https://naviteri.org/2011/03/word-order-and-case-marking-with-modals/}
 
 
 \subsubsection{} Known modal verbs and verbs with modal
@@ -1261,13 +1261,13 @@ syntax:\footnote{\QUAESTIO{Other candidates: \N{flä} \E{succeed},
 \index{var@\textbf{var}!modal}\index{zene@\textbf{zene}!modal}
 \index{zenke@\textbf{zenke}!modal}\index{may'@\textbf{may'}!modal}\index{kom@\textbf{kom}!modal}
 
-\noindent\NTeri{25/5/2011}{http://naviteri.org/2011/05/some-miscellaneous-vocabulary/}
-\LNWiki{1/12/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/October-December\%23As_X_as_Y.3B_Keep_on_keepin.27_on}
-\LNWiki{2/2/2011}{http://wiki.learnnavi.org/index.php/Canon/2011/January-March\%23Stop.21}
-\Ultxa{2/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23.C3.ACm.C3.ACy_and_modal_kan}
-\LNWiki{13/12/2012}{http://wiki.learnnavi.org/index.php/Canon/2012/July-December\%23.22sto.22_has_the_same_syntax_as_.22new.22}
-\NTeri{6/6/2019}{http://naviteri.org/2019/06/50a-liu-amip-40-new-words\%ef\%bb\%bf/}
-\NTeri{23/12/2020}{http://naviteri.org/2020/12/mrra-tipangkxotsyip-five-little-discussions/}
+\noindent\NTeri{25/5/2011}{https://naviteri.org/2011/05/some-miscellaneous-vocabulary/}
+\LNWiki{1/12/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/October-December\%23As_X_as_Y.3B_Keep_on_keepin.27_on}
+\LNWiki{2/2/2011}{https://wiki.learnnavi.org/index.php/Canon/2011/January-March\%23Stop.21}
+\Ultxa{2/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23.C3.ACm.C3.ACy_and_modal_kan}
+\LNWiki{13/12/2012}{https://wiki.learnnavi.org/index.php/Canon/2012/July-December\%23.22sto.22_has_the_same_syntax_as_.22new.22}
+\NTeri{6/6/2019}{https://naviteri.org/2019/06/50a-liu-amip-40-new-words\%ef\%bb\%bf/}
+\NTeri{23/12/2020}{https://naviteri.org/2020/12/mrra-tipangkxotsyip-five-little-discussions/}
 
 \subsubsection{} Note that the modal verbs are considered intransitive
 with the subject of the modal phrase in the subjective case,
@@ -1341,7 +1341,7 @@ teylu}. \index{new@\textbf{new}!causative}
 %The verb is transitive in this construction, and the subclause is
 %attached to \N{a fì'ut} or \N{futa} (\horenref{syn:clause-nom}) and
 %takes the subjunctive. \label{syn:modal:new}\index{new@\textbf{new}}
-%\LNWiki{20/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+%\LNWiki{20/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
 %
 %\begin{quotation}
 %\noindent \N{Oel new futa po kivä} \E{I want him to go} (lit. \E{I
@@ -1400,14 +1400,14 @@ noun describing the action of the verb (\horenref{lingop:gerund}).
 They can be used with adverbs (\horenref{syn:adverbs:gerund}),
 but they may not take subjects or direct objects, \Npawl{tìyusom
 'o' lu} \E{eating is fun}.\label{syn:gerund}
-\LNWiki{18/6/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Fwa_with_adpositions}
+\LNWiki{18/6/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Fwa_with_adpositions}
 
 \subsubsection{} English often uses gerunds to nominalize a phrase
 (``running a mara\-thon is difficult'').  In Na'vi such clause
 nominalization is handled with \N{fì'u} or \N{tsa'u} 
 (\horenref{syn:clause-nom}), \Npawl{\uwave{fwa yom teylut} 'o' lu}
 \E{\uwave{eating teylu} is fun}.\index{gerund!use}
-\Ultxa{3/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Gerunds_vs._Fwa}
+\Ultxa{3/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Gerunds_vs._Fwa}
 
 
 \section{Reflexive}
@@ -1416,7 +1416,7 @@ nominalization is handled with \N{fì'u} or \N{tsa'u}
 indicates the subject of the verb is performing an act on themself.
 The subject is in the subjective, not agentive, case, as in \Npawl{oe
 tsäpe'a} \E{I see myself}.
-\LNWiki{1/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Reflexives_and_Naming}
+\LNWiki{1/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Reflexives_and_Naming}
 
 \subsection{Intransitive Reflexives} With intransitive verbs that take
 dative objects reflexive pro\-noun \N{sno} is used,
@@ -1425,7 +1425,7 @@ dative objects reflexive pro\-noun \N{sno} is used,
 \begin{quotation}
 \noindent\N{Po yawne lu snor.} \E{He loves himself.}
 \end{quotation} \index{sno@\textbf{sno}!with intransitive reflexives}
-\noindent \NTeri{31/12/2011}{http://naviteri.org/2011/12/one-more-for-2011/}
+\noindent \NTeri{31/12/2011}{https://naviteri.org/2011/12/one-more-for-2011/}
 
 \subsection{Detransitive} The reflexive infix may also be used to
 create intransitive verbs,\footnote{Students of Romance languages will
@@ -1436,7 +1436,7 @@ voiture}.} such as \N{win säpi} \E{to hurry}.
 \N{fìtsap} \E{each other,} the meaning is reciprocal, \Npawl{mefo
 fìtsap mäpoleyam tengkrr tsngawvìk} \E{the two of them hugged each
 other and wept}.
-\NTeri{30/10/2011}{http://naviteri.org/2011/10/more-vocabulary-a-bit-of-grammar/}
+\NTeri{30/10/2011}{https://naviteri.org/2011/10/more-vocabulary-a-bit-of-grammar/}
 \index{fiìtsap@\textbf{fìtsap}}\index{reciprocal}
 
 \subsubsection{} With intransitive verbs that take dative objects
@@ -1454,7 +1454,7 @@ there are two possibilities,
 \noindent\Npawl{Fo smon (snoru) fìtsap nìwotx.} \E{They all know each other}.
 \end{quotation}
 
-\noindent \NTeri{31/12/2011}{http://naviteri.org/2011/12/one-more-for-2011/}
+\noindent \NTeri{31/12/2011}{https://naviteri.org/2011/12/one-more-for-2011/}
 
 \section{Causative}
 \noindent The causative infix \N{\INF{eyk}} increases the transitivity
@@ -1502,7 +1502,7 @@ direct object is considered irrelevant and only the verbal action
 matters. For example, \N{oe taron} \E{I hunt} is a general statement
 about one's activities, where what one is hunting in particular
 doesn't matter. Or, \index{antipassive} \index{ambitransitive}
-\NTeri{28/3/2012}{http://naviteri.org/2012/03/spring-vocabulary-part-1/}
+\NTeri{28/3/2012}{https://naviteri.org/2012/03/spring-vocabulary-part-1/}
 
 \begin{quotation}
 \noindent\Npawl{Ngal pelun faystxenut frakrr tsyär?}\\
@@ -1532,7 +1532,7 @@ in the causa\-tive.  For example, the resulting action of the sentence
 \E{he hunts (something we don't care about)} or \N{pol taron} \E{he
 hunts (something in particular)}.
 \index{antipassive!causative}
-\Ultxa{3/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Causative_for_ambitransitive_verbs}
+\Ultxa{3/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Causative_for_ambitransitive_verbs}
 
 
 \section{Commands}
@@ -1558,7 +1558,7 @@ usual negative adverb \N{ke}, but rather use the word \N{rä'ä}, as in
 
 \subsubsection{} \N{Rä'ä} may follow the verb for special emphasis,
 \Npawl{oeti 'ampi rä'ä, ma skxawng!} \E{don't touch me, you moron!}
-\NTeri{27/11/2012}{http://naviteri.org/2012/11/renu-ayinanfyaya-the-senses-paradigm/}
+\NTeri{27/11/2012}{https://naviteri.org/2012/11/renu-ayinanfyaya-the-senses-paradigm/}
 
 \subsubsection{} With \N{si}-construction verbs, \N{rä'ä} intrudes
 between the noun and \N{si}, \N{txopu rä'ä si} \E{don't be afraid},
@@ -1583,7 +1583,7 @@ answer to \Npawl{nga ke lu Txewì srak?} \E{you're not Txewi?}
 is \N{srane} if you are not, and \N{kehe} if you are.  Note that
 English handles this situation differently, and English speakers will
 need to take care with how they answer negative questions.
-\NTeri{28/2/2018}{http://naviteri.org/2018/02/negative-questions-in-navi/}
+\NTeri{28/2/2018}{https://naviteri.org/2018/02/negative-questions-in-navi/}
 
 \subsection{Ftxey... Fuke} In addition to \N{srak(e)} a yes-no
 question can be made with an idiom using \N{ftxey} \E{choose} and
@@ -1591,7 +1591,7 @@ question can be made with an idiom using \N{ftxey} \E{choose} and
 \E{are you coming} or \Npawl{ftxey nga za'u fuke} \E{are you coming or
 not?} \index{ftxey@\textbf{ftxey}}\index{fuke@\textbf{fuke}}
 \index{question!direct with \textbf{ftxey... fuke}}\label{syn:question:ftxey}
-\LNWiki{24/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23If_and_Whether}
+\LNWiki{24/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23If_and_Whether}
 
 \subsection{Wh-Questions} Use of a question word that contains
 \N{-pe+} is sufficient to create a quest\-ion, \N{kempe si nga?} \E{what
@@ -1605,7 +1605,7 @@ The Na'vi tag question (Eng. ``right?'', Fr. ``n'est-ce pas?'') is
 marked with either \N{kefya srak} or simply \N{kefyak} (ultimately
 derived from \N{ke fìfya srak?}).
 \index{question!tag}\index{kefak, kefya srak@\textbf{kefyak, kefya srak}}
-\LNWiki{1/3/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Tag_Question}
+\LNWiki{1/3/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Tag_Question}
 
 \subsection{Conjectural Questions} Questions which the speaker
 doesn't expect even the listeners to know the answer to are marked
@@ -1613,12 +1613,12 @@ with the evidential infix \N{\INF{ats}}, \Npawl{pol pesenget tatsok?}
 \E{where in the world could she be?} \Npawl{srake pxefo li
 polähatsem?} \E{I wonder if the three of them have already arrived.}
 \index{evidential!in questions}\index{question!conjectural}
-\NTeri{30/10/2011}{http://naviteri.org/2011/10/more-vocabulary-a-bit-of-grammar/}
+\NTeri{30/10/2011}{https://naviteri.org/2011/10/more-vocabulary-a-bit-of-grammar/}
 
 \subsection{Choice Questions} A question in which the speaker offers two choices is formed by placing \N{fu} before each choice, \Npawl{Nulnew ngal fu fì’ut fu tsa’ut?}
 \E{Do you want this or that?}
 \index{question!with choices}\
-\NTeri{30/09/2019}{http://naviteri.org/2019/09/choice-statements-vs-choice-questions-and-some-insults/}
+\NTeri{30/09/2019}{https://naviteri.org/2019/09/choice-statements-vs-choice-questions-and-some-insults/}
 
 \section{Affect and Evidence}
 
@@ -1632,7 +1632,7 @@ akewong ontu teya längu} \E{his alien smell fills my nose}.
 \subsubsection{} If a statement inherently encodes very positive or
 negative emotion the infix is likely to be omitted, as in \Npawl{nga
 yawne lu oer} \E{I love you}.
-\LNWiki{1/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+\LNWiki{1/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
 
 \subsection{Evidence} The second position infix \N{\INF{ats}} is used
 to mark a suppositional statement from evidence,\footnote{This roughly
@@ -1642,8 +1642,8 @@ rained'' or ``he must be having trouble with his homework.''}
 \E{something must have fright\-ened the banshee, because it suddenly
 took to the air.}
 \index{evidential}
-\LNWiki{19/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Evidential}
-%\NTeri{9/1/2012}{http://naviteri.org/2012/01/mipa-zisit-ayliu-amip-new-words-for-the-new-year/}
+\LNWiki{19/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Evidential}
+%\NTeri{9/1/2012}{https://naviteri.org/2012/01/mipa-zisit-ayliu-amip-new-words-for-the-new-year/}
 
 % see def of yawo for example of evidential
 %example of evidential 
@@ -1675,19 +1675,19 @@ See \horenref{syntax:prohibitions}.\index{prohibitions}
 the verb, \Npawl{ke'u ke lu ngay} \E{nothing is true}, \N{slä ke
 stä'nì kawkrr} \E{but (he) never catches (her)}.
 \index{negation!double negatives}\label{syn:neg:pleon}
-\LNWiki{2/5/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Double_Negatives_Required}
+\LNWiki{2/5/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23Double_Negatives_Required}
 
 \subsubsection{} When the prenoun \N{fra-} is negated the verb is also
 negated, \Npawl{ke frapo ke tslolam} \E{not everyone understood}.
 \index{fra-@\textbf{fra-}!with \textbf{ke}}
 \index{ke@\textbf{ke}!with \textbf{fra-}}
-\Ultxa{3/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Ke_with_fra-}
+\Ultxa{3/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Ke_with_fra-}
 
 \subsection{Kaw'it} A word or phrase may be singled out for negation
 with \N{ke... kaw\ACC{'it}} \E{not... at all}, as in \N{fo ke lu 'ewan
 kaw'it} \E{they are not young at all}.
 \index{kaw'it@\textbf{kaw'it}}
-\LNWiki{6/4/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23April_6_Miscellany}
+\LNWiki{6/4/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23April_6_Miscellany}
 
 
 \section{Complex Sentences}
@@ -1778,7 +1778,7 @@ object in that relative clause, it is omitted,
 \noindent For other cases or adpositional phrases, a resumptive
 pronoun must be used --- \N{po} for animate heads and \N{tsaw} for
 inanimates.
-% Feb 18: http://wiki.learnnavi.org/index.php/Canon#More_extracts_from_various_emails
+% Feb 18: https://wiki.learnnavi.org/index.php/Canon#More_extracts_from_various_emails
 
 \begin{quotation}
 \noindent \Npawl{poru mesyal lu a ikran} \E{an ikran with two wings}\\
@@ -1793,7 +1793,7 @@ object in it, the subject of the verb must still take the agentive
 marking, as in \N{\uwave{ngal} tse'a a tute} \E{the man whom you see}
 from above, not *\N{\uwave{nga} tse'a a tute} and \Npawl{teylu a
 \uwave{oel} yerom lu ftxìlor} \E{the teylu I'm eating is delicious}.
-\NTeri{28/3/2012}{http://naviteri.org/2012/03/spring-vocabulary-part-1/}
+\NTeri{28/3/2012}{https://naviteri.org/2012/03/spring-vocabulary-part-1/}
 
 \subsection{Other Attributive Phrases} Though English can
 modify nouns directly with pre\-posi\-tional phrases (``the man on the
@@ -1869,7 +1869,7 @@ discussed.  This subtlety is not required, however, and forms in
 \index{tsawa@\textbf{tsawa}!use}
 \index{tsata@\textbf{tsata}!use}
 \index{tsaria@\textbf{tsaria}!use}
-\LNWiki{18/6/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23The_contrast_between_fwa.2Ftsawa.2C_furia.2Ftsaria}
+\LNWiki{18/6/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23The_contrast_between_fwa.2Ftsawa.2C_furia.2Ftsaria}
 
 \subsubsection{} The noun \N{tìkin} \E{need} is used with an
 attributive clause for the idiom ``need to,'' \Npawl{awngaru lu tìkin
@@ -1885,7 +1885,7 @@ English conjunctions and gerund clauses.  \N{Oe ke tsun stivawm
 fayfnelì'ut \uwave{luke fwa sngä'i tsngi\-vaw\-vìk}} \E{I cannot hear
 such words \uwave{without starting to cry}}.\label{syn:rel:nom-adp}
 \index{adpositions!with nominalized clauses}
-% http://forum.learnnavi.org/language-updates/txelanit-hivawl/
+% https://forum.learnnavi.org/language-updates/txelanit-hivawl/
 
 
 \subsubsection{} \QUAESTIO{A list of legal ones might be nice. Other
@@ -1893,7 +1893,7 @@ likely candidates: \N{fpi}, \N{mìkam},  \N{pxel/na}?  Or the
 dictionary may be the better place for a full list.}  
 
 % Mungwrr fwa seen:
-%  http://naviteri.org/2020/02/some-words-for-leap-year-day/
+%  https://naviteri.org/2020/02/some-words-for-leap-year-day/
 % Vat fwa seen:
 %  https://naviteri.org/2012/03/spring-vocabulary-part-1/
 
@@ -1923,15 +1923,15 @@ sometimes with sound changes.
 \index{takrra@\textbf{takrra}}\index{akrrta@\textbf{akrrta}}
 \index{kuma@\textbf{kuma}}\index{akum@\textbf{akum}}
 \index{krr@\textbf{krr}!with attributive \N{a}}
-\NTeri{31/3/2012}{http://naviteri.org/2012/03/spring-vocabulary-part-2/}
-\NTeri{19/6/2012}{http://naviteri.org/2012/06/spring-vocabulary-part-3/}
+\NTeri{31/3/2012}{https://naviteri.org/2012/03/spring-vocabulary-part-2/}
+\NTeri{19/6/2012}{https://naviteri.org/2012/06/spring-vocabulary-part-3/}
 
 \noindent \Npawl{Tì'eyngit oel tolel \uwave{a krr}, ayngaru payeng}
 \E{\uwave{when} I receive an answer, I will let you know} could also
 be \N{krra tì'eyngit oel tolel, \dots}
-\LNWiki{1/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Some_Conjunctions_and_Adverbs}
-\LNWiki{1/2/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
-\NTeri{15/8/2011}{http://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\%23comment-986}
+\LNWiki{1/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Some_Conjunctions_and_Adverbs}
+\LNWiki{1/2/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+\NTeri{15/8/2011}{https://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/\%23comment-986}
 
 
 
@@ -1950,7 +1950,7 @@ indicative in the consequent,} \Npawl{txo fkol ke fyivel uranit paywä,
 zene fko slivele} \E{if one does not seal a boat against water, one
 must swim.}
 \index{conditional sentence!general}
-\NTeri{19/6/2012}{http://naviteri.org/2012/06/spring-vocabulary-part-3/}
+\NTeri{19/6/2012}{https://naviteri.org/2012/06/spring-vocabulary-part-3/}
 
 \subsection{Future Conditional} In English future conditionals have
 the present tense in the con\-dition and the future in the consequent,
@@ -2008,7 +2008,7 @@ subjunctive,
 \noindent\Npawl{Zun tompa zìyevup trray, zel fo srew.}\\
 \indent\E{If it rained tomorrow, they'd do a dance.}
 \end{quotation}
-\NTeri{4/30/2013}{http://naviteri.org/2013/04/zun-zel-counterfactual-conditionals/}
+\NTeri{4/30/2013}{https://naviteri.org/2013/04/zun-zel-counterfactual-conditionals/}
 
 \subsection{Imperatives in Conditions} When imperatives are used as
 the consequent of a condition, imperative mood and syntax rules
@@ -2027,7 +2027,7 @@ conjunctions that require no special comment.
 apposition, \Npawl{tskalepit oel tolìng oeyä \uwave{tsmu\-ka\-nur alu
 Ìstaw}} \E{I gave the crossbow to \uwave{my brother Istaw}}.  Note
 that the noun after \N{alu} is in the subjective case.
-\NTeri{16/7/2010}{http://naviteri.org/2010/07/vocabulary-update/}
+\NTeri{16/7/2010}{https://naviteri.org/2010/07/vocabulary-update/}
 \index{alu@\textbf{alu}}\label{syn:conj:alu}\index{apposition}
 
 \subsubsection{} \N{Alu} may also be used conversationally to mark a
@@ -2069,7 +2069,7 @@ vs.\ \Npawl{nulnew ngal \uwave{fu} fì’ut \uwave{fu} tsa’ut?}
 is paired with the negative adverb \N{ke}.  Take care to distinguish
 this from \N{slä} \E{but}.  \Npawl{Nga plltxe ke nìfyeyntu ki
 nì'eveng} \E{you speak not like an adult but a child.}
-\NTeri{16/7/2010}{http://naviteri.org/2010/07/vocabulary-update/}
+\NTeri{16/7/2010}{https://naviteri.org/2010/07/vocabulary-update/}
 \index{ki@\textbf{ki}}
 
 \subsection{Sì} The conjunction \N{sì} \E{and} is used for making lists
@@ -2106,7 +2106,7 @@ Na'vi}.  \index{siì@\textbf{sì}!enclitic}
 as} requires it to be used with the imperfective, \Npawl{fìtxon yom
 \uwave{tengkrr teruvon}} \E{on this night (we) eat \uwave{while leaning}}.
 \index{tengkrr@\textbf{tengkrr}}
-\LNWiki{14/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
+\LNWiki{14/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23A_Collection}
 
 \subsection{Tìk} \index{tìk@\textbf{tìk}} \label{syn:tìk}
 This adverb meaning \E{immediately, without delay,} can also be used
@@ -2114,14 +2114,14 @@ as a conjunction indicating that a second action immediately follows a
 first, \Npawl{fìioang ke tsun slivele; nemfapay zup tìk
 spakat} \E{this animal cannot swim; (if) it falls into the water, it
 immediately drowns}.
-\NTeri{31/12/2021}{http://naviteri.org/2021/12/zolau-niprrte-ma-3746-welcome-2022/}
+\NTeri{31/12/2021}{https://naviteri.org/2021/12/zolau-niprrte-ma-3746-welcome-2022/}
 
 \subsection{Tsnì} \label{syn:tsni}\index{tsnì@\textbf{tsnì}}
 The conjunction \N{tsnì} \E{that} introduces some kinds of report
 clause, \N{ätxäle si tsnì livu oheru Uniltaron} \E{I respectfully
 request the Dream Hunt}, \Npawl{sìlpey oe tsnì fìtìoeyktìng law livu
 ngaru set} \E{I hope that this explanation is clear to you now}.
-\NTeri{20/2/2011}{http://naviteri.org/2011/02/new-vocabulary-part-2/}
+\NTeri{20/2/2011}{https://naviteri.org/2011/02/new-vocabulary-part-2/}
 
 \subsubsection{} Verbs known to take \N{tsnì}: \N{ätxäle si},
 \N{rangal} (a marginal use), \N{sìlpey}, \N{la'um}, \N{mowar
@@ -2130,8 +2130,8 @@ and \N{srefpìl}.  Some verbs, such as \N{sìlpey} \E{hope,} require
 the \N{tsnì} clause to take the subjunctive, while others, such
 as \N{la'um} \E{pretend,} will not take the subjunctive.  The
 dictionary is the best place to verify.
-\LNForum{18/8/2011}{http://forum.learnnavi.org/language-updates/confirmation-on-use-of-rangal/}
-\NTeri{1/3/2020}{http://naviteri.org/2020/02/some-words-for-leap-year-day/\#comment-30895}
+\LNForum{18/8/2011}{https://forum.learnnavi.org/language-updates/confirmation-on-use-of-rangal/}
+\NTeri{1/3/2020}{https://naviteri.org/2020/02/some-words-for-leap-year-day/\#comment-30895}
 
 \subsection{Ulte} This conjunction connects clauses, \N{oel ngati
 kameie, ma tsmu-kan, \uwave{ulte} ngaru seiyi irayo} \E{I see you,
@@ -2151,7 +2151,7 @@ quotation, with the quoted words put between the particles \N{san} and
 nìprrte' ne pìlok Na'viteri sìk}!} \E{but now I can finally say
 ``\uwave{welcome to the blog Na'viteri}.''}\index{quotation!direct}
 \index{san@\textbf{san}}\index{siìk@\textbf{sìk}}
-\NTeri{31/8/2011}{http://naviteri.org/2011/08/reported-speech-reported-questions/}
+\NTeri{31/8/2011}{https://naviteri.org/2011/08/reported-speech-reported-questions/}
 
 \subsubsection{} If the beginning or end of a quotation coincides with
 the beginning or end of an utterance, one or the other of the
@@ -2169,36 +2169,36 @@ the beginning or end of an utterance, one or the other of the
 need to close the quotation with \N{sìk}.  Similarly, \N{san} can be
 dropped if there no serious ambiguity, \Npawl{frawzo sìk, slä oel poet
 ke spaw} \E{(she said) ``all's well,'' but I don't believe her}. 
-\LNWiki{21/1/2010}{http://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
+\LNWiki{21/1/2010}{https://wiki.learnnavi.org/index.php/Canon\%23Extracts_from_various_emails}
 \LNForum{4/8/2020}{https://forum.learnnavi.org/language-updates/on-omitting-san/}
 
 \subsection{Questions} Reported questions are also quoted directly,
 \Npawl{polawm po san srake Säli holum sìk} \E{he asked whether Sally
 left,} literally \E{he asked, ``did Sally leave?''}
-\LNWiki{24/3/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23If_and_Whether}
+\LNWiki{24/3/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/March-June\%23If_and_Whether}
 
 \subsubsection{} With \N{pawm}, but not other verbs of speaking,
 \N{san... sìk} may be dropped, \Npawl{Polawm po, Neytiri kä pesengne?}
 \E{he asked where Neytiri was going.}
-\NTeri{31/8/2011}{http://naviteri.org/2011/08/reported-speech-reported-questions/}
+\NTeri{31/8/2011}{https://naviteri.org/2011/08/reported-speech-reported-questions/}
 
 
 \subsection{Transitivity} When a verb of speaking uses \N{san...  sìk}
 it follows intransitive syntax, \N{po poltxe san srane} \E{she said
 ``yes.''} \index{transitivity!with verbs of speaking}
-\Ultxa{2/10/2010}{http://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Transitivity_with_Speaking_Verbs}
+\Ultxa{2/10/2010}{https://wiki.learnnavi.org/index.php/Canon/2010/UltxaAyharyu\%C3\%A4\%23Transitivity_with_Speaking_Verbs}
 
 \subsubsection{} When the speaking verb has a direct object, it
 follows transitive syntax, \Npawl{ke poltxe pol tsaylì'ut} \E{she
 didn't say that}, \N{oel poru pasyawm tsat} \E{I will ask him that}.
-\NTeri{31/8/2011}{http://naviteri.org/2011/08/reported-speech-reported-questions/}
+\NTeri{31/8/2011}{https://naviteri.org/2011/08/reported-speech-reported-questions/}
 
 \subsection{Quotation Nominalization} In addition to the
 \N{san... sìk} pair, reported speech may be anchored to the nouns
 \N{fmawn} \E{news}, \N{tì'eyng} \E{answer} and \N{faylì'u} \E{these
 words} with the attributive \N{a} (see \horenref{morph:fmawn} for
 contractions).
-\NTeri{31/8/2011}{http://naviteri.org/2011/08/reported-speech-reported-questions/}
+\NTeri{31/8/2011}{https://naviteri.org/2011/08/reported-speech-reported-questions/}
 
 \begin{center}
 \begin{tabular}{ll}
@@ -2248,7 +2248,7 @@ the film, \N{makto ko} \E{let's ride}.
 
 \subsubsection{} In the special case of \N{siva ko} \E{rise to the challenge}, 
 the phrase can be written as a single word: \N{sivako}.
-\NTeri{3/8/2019}{http://naviteri.org/2016/06/mrrvola-lifyavi-amip-forty-new-expressions/comment-page-1/\%23comment-30185}
+\NTeri{3/8/2019}{https://naviteri.org/2016/06/mrrvola-lifyavi-amip-forty-new-expressions/comment-page-1/\%23comment-30185}
 
 \subsection{Nang} This particle marks surprise, exclamation or
 encouragement.  It is always sentence-final and appears with adverbs


### PR DESCRIPTION
The Following fixes are included in this MR:

[x] Horen 3.1.1.5 contains a repeated 'and'
[x] Horen 3.2.2 missing new honorific 3rd person pronouns (poho, pohe, pohan)
[x] Horen 3.4.1.1 Link broken (https://naviteri.org/2011/07/number-in-na%E2%80%99vi/)
[x] Horen 6.8.3.2 Modals list missing nulnew (nul-new, nuln..ew) vtrm. prefer, - https://naviteri.org/2020/12/mrra-tipangkxotsyip-five-little-discussions/
[x] Horen 6.8.4.1 Link broken (https://wiki.learnnavi.org/Canon/2010/UltxaAyharyu%C3%A4#He_made_me_want_to_make_you_eat_teylu)
[x] Horen 6.23.1.2 link improvement suggestion - https://naviteri.org/2011/04/%e2%80%99a%e2%80%99awa-li%e2%80%99fyavi-amip%e2%80%94a-few-new-expressions/ (more specific link to exact post than the previous archive link)
[x] Horen Update all http URLs to https

The following are questions I had, or some things that could be suggestions for future changes, depending on if they are deemed legitimate.

[?] Horen 3.4 table all -> every? ; tsatu -> tsapo?
[?] Horen 3.6.2 Next-to-last syllable? Only works for 2-syllable regulars
[?] Horen 6.18.3.2 Typo of lì'Ona? (what is the real canon form of this clan name?)
[?] Horen 6.20.3 Another l'Ona?

Note: Title page and Change log may need to be updated. Those updates not included.