### PR TITLE
Fix typos of "lor" and "alor"

### DIFF
--- a/en/syntax.tex
+++ b/en/syntax.tex
@@ -231,13 +231,13 @@ other than  Adj - N - Adj given above, the adjectives can be put
 into an attributive clause with \N{lu},
 
 \begin{interlin}
-\glll yayo a lu lur sì hì'i \\
-      yayo a lu lur sì hì'i \\
+\glll yayo a lu lor sì hì'i \\
+      yayo a lu lor sì hì'i \\
       bird \I{rel} be pretty and small \\
 \trans{a small, pretty bird} \Ipawl{}
 \end{interlin}
 
-\noindent However, \N{yayo alur sì hì'i} (without \N{lu}) is permitted,
+\noindent However, \N{yayo alor sì hì'i} (without \N{lu}) is permitted,
 though not preferred.  This is much more likely and acceptible when a
 third adjective is involved in the clause,
 


### PR DESCRIPTION
This commit fixes typographical errors In the Syntax section, where there were instances of *`lur` and *`alur` that were clearly meant to be `lor` and `alor` respectively.